### PR TITLE
Fix ament packaging

### DIFF
--- a/cmake_utils/CMakeLists.txt
+++ b/cmake_utils/CMakeLists.txt
@@ -29,6 +29,8 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/project/installation_paths.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/project/configure_project.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/project/cmake_options.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/packaging/install_resources.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/packaging/install_package_xml.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/packaging/install_ament_index.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/packaging/eProsima_packaging.cmake)
 
 # Get all variables for project

--- a/cmake_utils/cmake/packaging/eProsima_packaging.cmake
+++ b/cmake_utils/cmake/packaging/eProsima_packaging.cmake
@@ -54,4 +54,10 @@ macro(eprosima_packaging)
 
     eprosima_install_resources()
 
+    # If compiled with ament, install the index ressources
+    if(DEFINED ENV{AMENT_PREFIX_PATH})
+        install_package_xml()
+        install_ament_index()
+    endif()
+
 endmacro()

--- a/cmake_utils/cmake/packaging/install_ament_index.cmake
+++ b/cmake_utils/cmake/packaging/install_ament_index.cmake
@@ -1,0 +1,45 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###############################################################################
+# Install ament index
+###############################################################################
+
+macro(install_ament_index)
+
+    file(
+        WRITE
+        ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME}
+        ""
+    )
+    install(
+        FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME}
+        DESTINATION
+        share/ament_index/resource_index/packages
+    )
+
+    file(
+        WRITE
+        ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv
+        "prepend-non-duplicate;AMENT_PREFIX_PATH;"
+    )
+    install(
+        FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv
+        DESTINATION
+        share/${PROJECT_NAME}/hook
+    )
+
+endmacro()

--- a/cmake_utils/cmake/packaging/install_package_xml.cmake
+++ b/cmake_utils/cmake/packaging/install_package_xml.cmake
@@ -1,0 +1,25 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###############################################################################
+# Install package.xml if it exists
+###############################################################################
+
+macro(install_package_xml)
+
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/package.xml)
+        install(FILES package.xml DESTINATION share/${PROJECT_NAME})
+    endif()
+
+endmacro()


### PR DESCRIPTION
Several packages provided by eProsima offer the possibility to be built with `colcon`. However said packages do not install their `package.xml` file nor do they populate the `ament index`.  
This PR add two macros to `cmake_utils` to do just that. Plus they are invoked from the `eprosima_packaging` macro when a build with ament is detected.

Note that of course packages that aren't using this macro will not benefit from this quick fix, e.g. fastdds.

Related to https://github.com/ros-infrastructure/rosdep/issues/724 