### PR TITLE
[18942] Include additional include paths when compiling a library

### DIFF
--- a/cmake_utils/cmake/compilation/compile_library.cmake
+++ b/cmake_utils/cmake/compilation/compile_library.cmake
@@ -114,6 +114,7 @@ function(compile_library _SOURCE_PATH _INCLUDE_PATH)
                 $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/${MODULE_NAME}>
                 $<BUILD_INTERFACE:${_SOURCE_PATH}>
                 $<INSTALL_INTERFACE:include>
+                $<INSTALL_INTERFACE:include/${MODULE_NAME}>
             )
 
         target_link_libraries(${MODULE_NAME}


### PR DESCRIPTION
This little PR adds the `include/PROJECT_NAME` paths to the include directories of the INSTALL_INTERFACE for a compiled library.