### PR TITLE
Fix TSAN tests compilation [20094]

### DIFF
--- a/.github/actions/tsan_workaround/action.yml
+++ b/.github/actions/tsan_workaround/action.yml
@@ -1,0 +1,15 @@
+name: tsan_workaround
+description: Install gcc-10 to copy its libtsan_preinit.o to gcc-9 (missing due to bug https://bugs.launchpad.net/ubuntu/+source/gcc-9/+bug/2029910).
+
+runs:
+  using: composite
+  steps:
+
+    - name: Download gcc-10 and copy file of interest
+      run: |
+
+        apt update && apt install libgcc-10-dev
+        dpkg -S libtsan_preinit.o
+        cp /usr/lib/gcc/x86_64-linux-gnu/10/libtsan_preinit.o /usr/lib/gcc/x86_64-linux-gnu/9
+
+      shell: bash

--- a/.github/actions/tsan_workaround/action.yml
+++ b/.github/actions/tsan_workaround/action.yml
@@ -8,8 +8,8 @@ runs:
     - name: Download gcc-10 and copy file of interest
       run: |
 
-        apt update && apt install libgcc-10-dev
+        sudo apt update && sudo apt install libgcc-10-dev
         dpkg -S libtsan_preinit.o
-        cp /usr/lib/gcc/x86_64-linux-gnu/10/libtsan_preinit.o /usr/lib/gcc/x86_64-linux-gnu/9
+        sudo cp /usr/lib/gcc/x86_64-linux-gnu/10/libtsan_preinit.o /usr/lib/gcc/x86_64-linux-gnu/9
 
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@
 #     - execute tests with ASAN flag
 #
 #   - tsan
-#     - ubuntu-22.04
+#     - ubuntu-20.04
 #     - execute tests with TSAN flag
 #
 #   - clang
@@ -144,7 +144,7 @@ jobs:
 # TSAN
 
   tsan:
-    # NOTE: there is a known issue in TSAN 20.04 with std::condition_variable::wait_for
+    # NOTE: there is a known issue in TSAN 22.04 with std::condition_variable::wait_for
     # https://github.com/google/sanitizers/issues/1259
     # Until this is fixed, we use 20.04 for TSAN work
     runs-on: ubuntu-20.04
@@ -163,10 +163,15 @@ jobs:
           dependencies_artifact_postfix: ${{ github.event.inputs.dependencies_artifact_postfix || env.default_dependencies_artifact_postfix }}
           secret_token: ${{ secrets.GITHUB_TOKEN }}
 
+      # NOTE: workaround for https://bugs.launchpad.net/ubuntu/+source/gcc-9/+bug/2029910
+      - name: TSAN workaround
+        uses: ./src/.github/actions/tsan_workaround
+
       - name: Compile and run tests
         uses: eProsima/eProsima-CI/multiplatform/tsan_build_test@v0
         with:
           packages_names: ${{ env.cpp_packages_names }}
+          cmake_args: -DCMAKE_CXX_FLAGS='-pthread'
           workspace_dependencies: './install'
 
 

--- a/cpp_utils/project_settings.cmake
+++ b/cpp_utils/project_settings.cmake
@@ -32,5 +32,15 @@ set(MODULE_DEPENDENCIES
         ${MODULE_FIND_PACKAGES}
     )
 
+###################################################################################
+# NOTE: workaround for https://bugs.launchpad.net/ubuntu/+source/gcc-9/+bug/2029910
+# Better be done with FindThreads.cmake as in Fast-DDS, but it's just a workaround
+set(CMAKE_THREAD_LIBS_INIT "-lpthread")
+set(CMAKE_HAVE_THREADS_LIBRARY 1)
+set(CMAKE_USE_WIN32_THREADS_INIT 0)
+set(CMAKE_USE_PTHREADS_INIT 1)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+###################################################################################
+
 set(MODULE_THIRDPARTY_HEADERONLY
     filewatch)


### PR DESCRIPTION
This is a workaround to tackle issue https://bugs.launchpad.net/ubuntu/+source/gcc-9/+bug/2029910. It consists of installing gcc-10 only to take an object file missing in gcc-9 (due to the mentioned bug), plus setting some cmake macros required for linking against libpthread.

Migrating to ubuntu 22 or using a higher gcc version was not a possibility as TSAN reports too many false positives for our code.

**NOTE**: to be reverted once the issue is solved.
