### PR TITLE
Disable FileWatcherHandler for macOS

### DIFF
--- a/cpp_utils/include/cpp_utils/event/FileWatcherHandler.hpp
+++ b/cpp_utils/include/cpp_utils/event/FileWatcherHandler.hpp
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#if !defined(__APPLE__)
+
 #include <functional>
 #include <string>
 
@@ -118,4 +120,4 @@ protected:
 } /* namespace utils */
 } /* namespace eprosima */
 
-
+#endif /* !defined(__APPLE__) */

--- a/cpp_utils/src/cpp/event/FileWatcherHandler.cpp
+++ b/cpp_utils/src/cpp/event/FileWatcherHandler.cpp
@@ -17,6 +17,8 @@
  *
  */
 
+#if !defined(__APPLE__)
+
 #include <cpp_utils/exception/InitializationException.hpp>
 #include <cpp_utils/Log.hpp>
 #include <cpp_utils/Formatter.hpp>
@@ -112,3 +114,5 @@ void FileWatcherHandler::callback_unset_nts_() noexcept
 } /* namespace event */
 } /* namespace utils */
 } /* namespace eprosima */
+
+#endif /* !defined(__APPLE__) */


### PR DESCRIPTION
The `FileWatcherHandler` will not compile on macOS because `FileWatch.hpp` is only implemented for  `_WIN32` and `__unix__`. The latter cannot be used on macOS because `#include <sys/inotify.h>` is not available.

This PR conditionally excludes the `FileWatcherHandler` class when building on macOS. The change is a pre-requisite for building Fast DDS Spy on macOS. 
 
### Related PRs for downstream packages

- https://github.com/eProsima/Fast-DDS-statistics-backend/pull/195 
- https://github.com/eProsima/Fast-DDS-spy/pull/54
- https://github.com/eProsima/Fast-DDS-monitor/pull/197
