### PR TITLE
Fix ros2_msgs_format in ROS 2 Mangling methods 

### DIFF
--- a/cpp_utils/src/cpp/ros2_mangling.cpp
+++ b/cpp_utils/src/cpp/ros2_mangling.cpp
@@ -30,7 +30,7 @@ const char* const ros_service_response_prefix = "rr";
 const std::vector<std::string> ros_prefixes_ =
 {ros_topic_prefix, ros_service_requester_prefix, ros_service_response_prefix};
 
-const char* const ros2_msgs_format = "_msgs/msg/";
+const char* const ros2_msgs_format = "/msg/";
 const char* const ros2_srv_format = "/srv/";
 
 std::string remove_prefix(


### PR DESCRIPTION
Refactor the `ros2_msgs_format` to accommodate diverse ROS 2 message types, which may include paths like `rcl_interfaces/msg/ParameterEvent`. The fix ensures flexibility by changing the format from `msg/msgs/` to `/msg/`. 