### PR TITLE
[19997] Fix eProsima software tools errors raising from Fast DDS update

### DIFF
--- a/cpp_utils/include/cpp_utils/event/impl/SignalManager.ipp
+++ b/cpp_utils/include/cpp_utils/event/impl/SignalManager.ipp
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <algorithm>
+#include <thread>
 
 #include <cpp_utils/exception/InconsistencyException.hpp>
 #include <cpp_utils/Log.hpp>

--- a/cpp_utils/src/cpp/event/PeriodicEventHandler.cpp
+++ b/cpp_utils/src/cpp/event/PeriodicEventHandler.cpp
@@ -17,6 +17,8 @@
  *
  */
 
+#include <thread>
+
 #include <cpp_utils/Log.hpp>
 #include <cpp_utils/event/PeriodicEventHandler.hpp>
 #include <cpp_utils/exception/InitializationException.hpp>

--- a/cpp_utils/src/cpp/event/StdinEventHandler.cpp
+++ b/cpp_utils/src/cpp/event/StdinEventHandler.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <thread>
+
 #include <cpp_utils/Log.hpp>
 #include <cpp_utils/event/StdinEventHandler.hpp>
 #include <cpp_utils/exception/InitializationException.hpp>

--- a/cpp_utils/test/unittest/wait/DBQueueWaitHandlerTest.cpp
+++ b/cpp_utils/test/unittest/wait/DBQueueWaitHandlerTest.cpp
@@ -14,6 +14,7 @@
 
 #include <cpp_utils/testing/gtest_aux.hpp>
 #include <gtest/gtest.h>
+#include <thread>
 
 #include <cpp_utils/wait/DBQueueWaitHandler.hpp>
 #include <cpp_utils/exception/DisabledException.hpp>


### PR DESCRIPTION
Add the <thread> library to files that require it. They are no longer included from FastDDS dependencies.