### PR TITLE
Add optional arguments to all_library_sources and add_unittest_executable

### DIFF
--- a/cmake_utils/cmake/test/test_target.cmake
+++ b/cmake_utils/cmake/test/test_target.cmake
@@ -132,10 +132,14 @@ endfunction(add_unittest_executable)
 # TEST_LIST -> test cases implemented in the Test .cpp
 # TEST_NEEDED_SOURCES -> source files required to be copies for the test execution
 # ARGV4 -> TEST_EXTRA_HEADERS -> extra headers needed for the test (fifth optional argument)
+# ARGV5 -> TEST_LIBRARY_SOURCES -> list of extra sources files for the test (sixth optional argument)
 function(add_blackbox_executable TEST_NAME TEST_SOURCES TEST_LIST TEST_NEEDED_SOURCES)
 
-    # Add all cpp files to sources
-    all_library_sources("${TEST_SOURCES}")
+    # Add cpp files to sources
+    all_library_sources(
+        "${TEST_SOURCES}"
+        "${ARGV5}"
+    )
 
     # Add all library needed by sources
     set(EXTRA_LIBRARIES

--- a/cmake_utils/cmake/test/test_utils.cmake
+++ b/cmake_utils/cmake/test/test_utils.cmake
@@ -15,19 +15,24 @@
 # Return a list of all cpp and hpp files in library
 # Arguments:
 # TEST_SOURCES -> List of source files where new sources will be added
+# ARGV1 -> List of source files to use (not TEST_SOURCES) (optional)
 function(all_library_sources TEST_SOURCES)
 
-    file(GLOB_RECURSE LIBRARY_SOURCES
-            "${PROJECT_SOURCE_DIR}/src/cpp/**/*.c"
-            "${PROJECT_SOURCE_DIR}/src/cpp/**/*.cpp"
-            "${PROJECT_SOURCE_DIR}/src/cpp/**/*.cxx"
-            "${PROJECT_SOURCE_DIR}/src/cpp/**/*.h"
-            "${PROJECT_SOURCE_DIR}/src/cpp/**/*.hpp"
-            "${PROJECT_SOURCE_DIR}/src/cpp/**/*.hxx"
-            "${PROJECT_SOURCE_DIR}/test/TestUtils/**/*.cpp"
-            "${PROJECT_SOURCE_DIR}/test/TestUtils/*.cpp"
-        )
-    set(NEW_TEST_SOURCES "${TEST_SOURCES};${LIBRARY_SOURCES}")
+    if ("${ARGV1}" STREQUAL "")
+        file(GLOB_RECURSE LIBRARY_SOURCES
+                "${PROJECT_SOURCE_DIR}/src/cpp/**/*.c"
+                "${PROJECT_SOURCE_DIR}/src/cpp/**/*.cpp"
+                "${PROJECT_SOURCE_DIR}/src/cpp/**/*.cxx"
+                "${PROJECT_SOURCE_DIR}/src/cpp/**/*.h"
+                "${PROJECT_SOURCE_DIR}/src/cpp/**/*.hpp"
+                "${PROJECT_SOURCE_DIR}/src/cpp/**/*.hxx"
+                "${PROJECT_SOURCE_DIR}/test/TestUtils/**/*.cpp"
+                "${PROJECT_SOURCE_DIR}/test/TestUtils/*.cpp"
+            )
+        set(NEW_TEST_SOURCES "${TEST_SOURCES};${LIBRARY_SOURCES}")
+    else()
+        set(NEW_TEST_SOURCES "${TEST_SOURCES};${ARGV1}")
+    endif()
     set(TEST_SOURCES ${NEW_TEST_SOURCES} PARENT_SCOPE)
 
 endfunction()


### PR DESCRIPTION
This pull request is essential for providing the flexibility to select specific source files for different scenarios. The previous version indiscriminately included all project files, whereas this update allows us to tailor our choices based on specific needs.