### PR TITLE
Utility to convert a string (e.g. 100MB) to a number of bytes

### DIFF
--- a/cpp_utils/include/cpp_utils/utils.hpp
+++ b/cpp_utils/include/cpp_utils/utils.hpp
@@ -101,7 +101,7 @@ void to_uppercase(
  * @return number of bytes
  */
 CPP_UTILS_DllAPI
-uint64_t to_bytes(
+std::uint64_t to_bytes(
         const std::string& input);
 
 template <typename T, bool Ptr = false>

--- a/cpp_utils/include/cpp_utils/utils.hpp
+++ b/cpp_utils/include/cpp_utils/utils.hpp
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <set>

--- a/cpp_utils/include/cpp_utils/utils.hpp
+++ b/cpp_utils/include/cpp_utils/utils.hpp
@@ -88,8 +88,21 @@ void to_lowercase(
  *
  * @param [in,out] st : string to modify
  */
-CPP_UTILS_DllAPI void to_uppercase(
+CPP_UTILS_DllAPI
+void to_uppercase(
         std::string& st) noexcept;
+
+/**
+ * @brief Convert a string to a number of bytes.
+ *
+ * The string must be a number followed by a magnitude (e.g. 10MB, 0.5GiB).
+ *
+ * @param input string to convert
+ * @return number of bytes
+ */
+CPP_UTILS_DllAPI
+unsigned long long to_bytes(
+        const std::string& input);
 
 template <typename T, bool Ptr = false>
 std::ostream& element_to_stream(

--- a/cpp_utils/include/cpp_utils/utils.hpp
+++ b/cpp_utils/include/cpp_utils/utils.hpp
@@ -101,7 +101,7 @@ void to_uppercase(
  * @return number of bytes
  */
 CPP_UTILS_DllAPI
-unsigned long long to_bytes(
+uint64_t to_bytes(
         const std::string& input);
 
 template <typename T, bool Ptr = false>

--- a/cpp_utils/src/cpp/utils.cpp
+++ b/cpp_utils/src/cpp/utils.cpp
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <iomanip>
 #include <sstream>
+#include <stdexcept>
 
 #include <cpp_utils/exception/PreconditionNotMet.hpp>
 #include <cpp_utils/Log.hpp>
@@ -97,6 +98,47 @@ void to_uppercase(
             {
                 return std::toupper(c);
             });
+}
+
+unsigned long long to_bytes(const std::string& input)
+{
+    static const std::map<std::string, unsigned long long> magnitudes = {
+        {"B", 1},
+        {"KB", 1000},
+        {"MB", 1000 * 1000},
+        {"GB", 1000 * 1000 * 1000},
+        {"TB", 1000LL * 1000 * 1000 * 1000},
+        {"PB", 1000LL * 1000 * 1000 * 1000 * 1000},
+        {"KIB", 1024},
+        {"MIB", 1024 * 1024},
+        {"GIB", 1024 * 1024 * 1024},
+        {"TIB", 1024ULL * 1024 * 1024 * 1024},
+        {"PIB", 1024ULL * 1024 * 1024 * 1024 * 1024}
+    };
+
+    // Find the number and the magnitude
+    std::regex pattern(R"((\d+(?:\.\d+)?)\s*([a-zA-Z]+))");
+    std::smatch matches;
+
+    if (!std::regex_match(input, matches, pattern) || matches.size() != 3)
+    {
+        throw std::invalid_argument("The quantity is not in the expected format. It should be a number followed by a magnitude (e.g. 10MB).");
+    }
+
+    // Extract the number
+    std::string number_str = matches[1].str();
+    double number = std::stod(number_str);
+
+    // Extract the magnitude
+    std::string magnitude_str = matches[2].str();
+    to_uppercase(magnitude_str);
+
+    const auto magnitude = magnitudes.at(magnitude_str);
+
+    // Calculate the number of bytes
+    const unsigned long long bytes = number * magnitude;
+
+    return bytes;
 }
 
 void tsnh(

--- a/cpp_utils/src/cpp/utils.cpp
+++ b/cpp_utils/src/cpp/utils.cpp
@@ -100,9 +100,10 @@ void to_uppercase(
             });
 }
 
-unsigned long long to_bytes(const std::string& input)
+uint64_t to_bytes(
+        const std::string& input)
 {
-    static const std::map<std::string, unsigned long long> magnitudes = {
+    static const std::map<std::string, uint64_t> magnitudes = {
         {"B", 1},
         {"KB", 1000},
         {"MB", 1000 * 1000},
@@ -122,7 +123,8 @@ unsigned long long to_bytes(const std::string& input)
 
     if (!std::regex_match(input, matches, pattern) || matches.size() != 3)
     {
-        throw std::invalid_argument("The quantity is not in the expected format. It should be a number followed by a magnitude (e.g. 10MB).");
+        throw std::invalid_argument(
+                  "The quantity is not in the expected format. It should be a number followed by a magnitude (e.g. 10MB).");
     }
 
     // Extract the number
@@ -135,8 +137,14 @@ unsigned long long to_bytes(const std::string& input)
 
     const auto magnitude = magnitudes.at(magnitude_str);
 
+    // Check for overflow
+    if (number > std::numeric_limits<uint64_t>::max() / magnitude)
+    {
+        throw std::invalid_argument("The number is too large to be converted to bytes.");
+    }
+
     // Calculate the number of bytes
-    const unsigned long long bytes = number * magnitude;
+    const uint64_t bytes = number * magnitude;
 
     return bytes;
 }

--- a/cpp_utils/src/cpp/utils.cpp
+++ b/cpp_utils/src/cpp/utils.cpp
@@ -139,7 +139,8 @@ std::uint64_t to_bytes(
 
     if (units.find(unit_str) == units.end())
     {
-        throw std::invalid_argument("The unit is not valid. The valid units are: B, KB, MB, GB, TB, PB, KiB, MiB, GiB, TiB, PiB.");
+        throw std::invalid_argument(
+                  "The unit is not valid. The valid units are: B, KB, MB, GB, TB, PB, KiB, MiB, GiB, TiB, PiB.");
     }
 
     const auto unit = units.at(unit_str);

--- a/cpp_utils/src/cpp/utils.cpp
+++ b/cpp_utils/src/cpp/utils.cpp
@@ -146,7 +146,8 @@ std::uint64_t to_bytes(
     const auto unit = units.at(unit_str);
 
     // Check whether the product of number * unit overflows
-    if (number > std::numeric_limits<std::uint64_t>::max() / unit)
+    // @note: The parentheses are necessary to distinguish std::max from the max macro (Windows).
+    if (number > (std::numeric_limits<std::uint64_t>::max)() / unit)
     {
         throw std::invalid_argument("The number is too large to be converted to bytes.");
     }

--- a/cpp_utils/src/cpp/utils.cpp
+++ b/cpp_utils/src/cpp/utils.cpp
@@ -19,11 +19,13 @@
 
 #include <algorithm>
 #include <assert.h>
-#include <set>
-#include <stdlib.h>
+#include <cstdint>
 #include <iomanip>
+#include <regex>
+#include <set>
 #include <sstream>
 #include <stdexcept>
+#include <stdlib.h>
 
 #include <cpp_utils/exception/PreconditionNotMet.hpp>
 #include <cpp_utils/Log.hpp>
@@ -108,8 +110,8 @@ std::uint64_t to_bytes(
         {"KB", 1000},
         {"MB", 1000 * 1000},
         {"GB", 1000 * 1000 * 1000},
-        {"TB", 1000LL * 1000 * 1000 * 1000},
-        {"PB", 1000LL * 1000 * 1000 * 1000 * 1000},
+        {"TB", 1000ULL * 1000 * 1000 * 1000},
+        {"PB", 1000ULL * 1000 * 1000 * 1000 * 1000},
         {"KIB", 1024},
         {"MIB", 1024 * 1024},
         {"GIB", 1024 * 1024 * 1024},
@@ -118,10 +120,10 @@ std::uint64_t to_bytes(
     };
 
     // Find the number and the magnitude
-    std::regex pattern(R"((\d+(?:\.\d+)?)\s*([a-zA-Z]+))");
+    std::regex pattern("^((\\d+)\\s*([a-zA-Z]+))$");
     std::smatch matches;
 
-    if (!std::regex_match(input, matches, pattern) || matches.size() != 3)
+    if (!std::regex_match(input, matches, pattern) || matches.size() != 2)
     {
         throw std::invalid_argument(
                   "The quantity is not in the expected format. It should be a number followed by a magnitude (e.g. 10MB).");
@@ -137,14 +139,15 @@ std::uint64_t to_bytes(
 
     const auto magnitude = magnitudes.at(magnitude_str);
 
-    // Check for overflow
+    // Check whether the product of number * magnitude overflows
     if (number > std::numeric_limits<std::uint64_t>::max() / magnitude)
     {
         throw std::invalid_argument("The number is too large to be converted to bytes.");
     }
 
-    // Calculate the number of bytes
-    const std::uint64_t bytes = number * magnitude;
+    // The explicit cast to uint64_t is safe since the number has already been checked to fit.
+    // The product is also safe since the possible overflow has also been checked.
+    const std::uint64_t bytes = static_cast<std::uint64_t>(number) * magnitude;
 
     return bytes;
 }

--- a/cpp_utils/src/cpp/utils.cpp
+++ b/cpp_utils/src/cpp/utils.cpp
@@ -100,10 +100,10 @@ void to_uppercase(
             });
 }
 
-uint64_t to_bytes(
+std::uint64_t to_bytes(
         const std::string& input)
 {
-    static const std::map<std::string, uint64_t> magnitudes = {
+    static const std::map<std::string, std::uint64_t> magnitudes = {
         {"B", 1},
         {"KB", 1000},
         {"MB", 1000 * 1000},
@@ -138,13 +138,13 @@ uint64_t to_bytes(
     const auto magnitude = magnitudes.at(magnitude_str);
 
     // Check for overflow
-    if (number > std::numeric_limits<uint64_t>::max() / magnitude)
+    if (number > std::numeric_limits<std::uint64_t>::max() / magnitude)
     {
         throw std::invalid_argument("The number is too large to be converted to bytes.");
     }
 
     // Calculate the number of bytes
-    const uint64_t bytes = number * magnitude;
+    const std::uint64_t bytes = number * magnitude;
 
     return bytes;
 }

--- a/cpp_utils/test/unittest/utils/CMakeLists.txt
+++ b/cpp_utils/test/unittest/utils/CMakeLists.txt
@@ -29,6 +29,7 @@ set(TEST_LIST
         are_set_of_ptr_equal_int
         to_lowercase
         to_uppercase
+        to_bytes
         tsnh_call
         is_file_accessible
         combined_file_permissions

--- a/cpp_utils/test/unittest/utils/utilsTest.cpp
+++ b/cpp_utils/test/unittest/utils/utilsTest.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <cstdint>
+#include <stdexcept>
 
 #include <cpp_utils/testing/gtest_aux.hpp>
 #include <gtest/gtest.h>
@@ -356,6 +358,90 @@ TEST(utilsTest, to_uppercase)
         std::string str = "";
         to_uppercase(str);
         ASSERT_EQ(str, "");
+    }
+}
+
+/**
+ * Test \c to_bytes call
+ */
+TEST(utilsTest, to_bytes)
+{
+    // VALID
+
+    // Invariant
+    {
+        const std::string bytes_str = "100B";
+        const std::uint64_t bytes = to_bytes(bytes_str);
+        const std::uint64_t bytes_expected = 100ULL;
+        ASSERT_EQ(bytes, bytes_expected);
+    }
+    // Lowercase
+    {
+        const std::string bytes_str = "123kb";
+        const std::uint64_t bytes = to_bytes(bytes_str);
+        const std::uint64_t bytes_expected = 123ULL * 1000;
+        ASSERT_EQ(bytes, bytes_expected);
+    }
+    // Uppercase
+    {
+        const std::string bytes_str = "100MB";
+        const std::uint64_t bytes = to_bytes(bytes_str);
+        const std::uint64_t bytes_expected = 100ULL * 1000 * 1000;
+        ASSERT_EQ(bytes, bytes_expected);
+    }
+    // Milibytes
+    {
+        const std::string bytes_str = "82GiB";
+        const std::uint64_t bytes = to_bytes(bytes_str);
+        const std::uint64_t bytes_expected = 82ULL * 1024 * 1024 * 1024;
+        ASSERT_EQ(bytes, bytes_expected);
+    }
+    // Large
+    {
+        const std::string bytes_str = "742TB";
+        const std::uint64_t bytes = to_bytes(bytes_str);
+        const std::uint64_t bytes_expected = 742ULL * 1000 * 1000 * 1000 * 1000;
+        ASSERT_EQ(bytes, bytes_expected);
+    }
+    // Extra Large
+    {
+        const std::string bytes_str = "51pib";
+        const std::uint64_t bytes = to_bytes(bytes_str);
+        const std::uint64_t bytes_expected = 51ULL * 1024 * 1024 * 1024 * 1024 * 1024;
+        ASSERT_EQ(bytes, bytes_expected);
+    }
+
+    // INVALID
+
+    // Empty
+    {
+        const std::string bytes_str = "";
+        ASSERT_THROW(to_bytes(bytes_str), std::invalid_argument);
+    }
+    // No unit
+    {
+        const std::string bytes_str = "100";
+        ASSERT_THROW(to_bytes(bytes_str), std::invalid_argument);
+    }
+    // No number
+    {
+        const std::string bytes_str = "MB";
+        ASSERT_THROW(to_bytes(bytes_str), std::invalid_argument);
+    }
+    // Invalid unit
+    {
+        const std::string bytes_str = "100G";
+        ASSERT_THROW(to_bytes(bytes_str), std::out_of_range);
+    }
+    // Invalid number
+    {
+        const std::string bytes_str = "100.5MB";
+        ASSERT_THROW(to_bytes(bytes_str), std::invalid_argument);
+    }
+    // Number too large
+    {
+        const std::string bytes_str = "18446744073709551616PiB";
+        ASSERT_THROW(to_bytes(bytes_str), std::invalid_argument);
     }
 }
 

--- a/cpp_utils/test/unittest/utils/utilsTest.cpp
+++ b/cpp_utils/test/unittest/utils/utilsTest.cpp
@@ -431,7 +431,7 @@ TEST(utilsTest, to_bytes)
     // Invalid unit
     {
         const std::string bytes_str = "100G";
-        ASSERT_THROW(to_bytes(bytes_str), std::out_of_range);
+        ASSERT_THROW(to_bytes(bytes_str), std::invalid_argument);
     }
     // Invalid number
     {


### PR DESCRIPTION
Convert to bytes a string with a floating number followed by either the letters B, KB, MB, GB, TB, PB or KiB, MiB, GiB, TiB, PiB (case insensitive).  