### PR TITLE
Empty XTSAN tests list

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,10 +144,7 @@ jobs:
 # TSAN
 
   tsan:
-    # NOTE: there is a known issue in TSAN 20.04 with std::condition_variable::wait_for
-    # https://github.com/google/sanitizers/issues/1259
-    # Until this is fixed, we use 20.04 for TSAN work
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Sync repository
@@ -158,7 +155,7 @@ jobs:
       - name: Download dependencies and install requirements
         uses: ./src/.github/actions/project_dependencies
         with:
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           cmake_build_type: Release
           dependencies_artifact_postfix: ${{ github.event.inputs.dependencies_artifact_postfix || env.default_dependencies_artifact_postfix }}
           secret_token: ${{ secrets.GITHUB_TOKEN }}

--- a/cpp_utils/test/labels/XTSAN.list
+++ b/cpp_utils/test/labels/XTSAN.list
@@ -1,4 +1,0 @@
-SignalEventHandlerTest.erase_callback_while_other_handling
-SignalEventHandlerTest.receive_n_signals
-SignalEventHandlerTest.receive_signal
-SignalEventHandlerTest.receive_signal_trivial


### PR DESCRIPTION
Up to https://github.com/eProsima/eProsima-CI/pull/77 , almost every test using Fast-DDS was reporting multiple TSAN warnings that were in fact false positives. For this reason these tests were categorized as flaky when running the TSAN action, but after the update in eProsima-CI they should no longer fail.