### PR TITLE
Utility to convert a number of bytes (e.g. 123456) to a formatted string (e.g. 123.46KB)

### DIFF
--- a/cpp_utils/include/cpp_utils/utils.hpp
+++ b/cpp_utils/include/cpp_utils/utils.hpp
@@ -96,7 +96,7 @@ void to_uppercase(
 /**
  * @brief Convert a string to a number of bytes.
  *
- * The string must be a number followed by a magnitude (e.g. 10MB, 0.5GiB).
+ * The string must be a number followed by a magnitude (e.g. 10MB, 5GiB).
  *
  * @param input string to convert
  * @return number of bytes
@@ -104,6 +104,21 @@ void to_uppercase(
 CPP_UTILS_DllAPI
 std::uint64_t to_bytes(
         const std::string& input);
+
+/**
+ * @brief Convert a number of bytes to a string.
+ *
+ * Examples:
+ *  - The number 0 will be converted to 0B.
+ *  - The number 1500 will be converted to 1.50KB.
+ *  - The number 555555555 will be converted to 555.56MB.
+ *
+ * @param bytes number to convert
+ * @return \c bytes converted to a string and formatted to the closest magnitude
+ */
+CPP_UTILS_DllAPI
+std::string from_bytes(
+        const std::uint64_t bytes);
 
 template <typename T, bool Ptr = false>
 std::ostream& element_to_stream(

--- a/cpp_utils/src/cpp/utils.cpp
+++ b/cpp_utils/src/cpp/utils.cpp
@@ -121,13 +121,13 @@ std::uint64_t to_bytes(
     };
 
     // Find the number and the unit
-    std::regex pattern("^(\\d+)\\s*([a-zA-Z]+)$");
+    std::regex pattern("^(\\d+(\\.\\d+)?)\\s*([a-zA-Z]+)$");
     std::smatch matches;
 
-    if (!std::regex_match(input, matches, pattern) || matches.size() != 3)
+    if (!std::regex_match(input, matches, pattern) || matches.size() != 4)
     {
         throw std::invalid_argument(
-                  "The quantity is not in the expected format. It should be a natural number followed by a unit (e.g. 10MB).");
+                  "The quantity is not in the expected format. It should be a rational number followed by a unit (e.g. 10MB).");
     }
 
     // Extract the number
@@ -135,7 +135,7 @@ std::uint64_t to_bytes(
     double number = std::stod(number_str);
 
     // Extract the unit
-    std::string unit_str = matches[2].str();
+    std::string unit_str = matches[3].str();
     to_uppercase(unit_str);
 
     if (units.find(unit_str) == units.end())
@@ -153,9 +153,8 @@ std::uint64_t to_bytes(
         throw std::invalid_argument("The number is too large to be converted to bytes.");
     }
 
-    // The explicit cast to uint64_t is safe since the number has already been checked to fit.
-    // The product is also safe since the possible overflow has also been checked.
-    const std::uint64_t bytes = static_cast<std::uint64_t>(number) * unit;
+    // The product is safe since the possible overflow has also been checked.
+    const std::uint64_t bytes = number * unit;
 
     return bytes;
 }

--- a/cpp_utils/src/cpp/utils.cpp
+++ b/cpp_utils/src/cpp/utils.cpp
@@ -163,6 +163,11 @@ std::uint64_t to_bytes(
 std::string from_bytes(
         const std::uint64_t bytes)
 {
+    if (bytes == 0)
+    {
+        return "0B";
+    }
+
     static const std::map<std::uint64_t, std::string> units = {
         {1, "B"},
         {1000, "KB"},
@@ -173,31 +178,18 @@ std::string from_bytes(
     };
 
     // Find the factor and unit
-    const auto it = std::find_if(units.begin(), units.end(),
-            [bytes](const std::pair<std::uint64_t, std::string>& unit)
-            {
-                return bytes / unit.first < 1000;
-            });
+    const auto it = std::upper_bound(units.begin(), units.end(), bytes,
+                    [](const std::uint64_t bytes, const std::pair<std::uint64_t, std::string>& unit)
+                    {
+                        return bytes < unit.first;
+                    });
 
-    std::uint64_t factor;
-    std::string unit;
-
-    if (it == units.end())
-    {
-        // The number is huge. Use the largest unit.
-        const auto largest_unit = units.rbegin();
-        factor = largest_unit->first;
-        unit = largest_unit->second;
-    }
-    else
-    {
-        factor = it->first;
-        unit = it->second;
-    }
+    const auto factor = std::prev(it)->first;
+    const auto unit = std::prev(it)->second;
 
     // Calculate the number
-    const double number_double = static_cast<double>(bytes) / factor;
-    const std::uint64_t number_int = static_cast<std::uint64_t>(number_double);
+    const auto number_double = static_cast<double>(bytes) / factor;
+    const auto number_int = static_cast<std::uint64_t>(number_double);
 
     // Format the number
     std::ostringstream oss;

--- a/cpp_utils/test/unittest/utils/CMakeLists.txt
+++ b/cpp_utils/test/unittest/utils/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_LIST
         to_lowercase
         to_uppercase
         to_bytes
+        from_bytes
         tsnh_call
         is_file_accessible
         combined_file_permissions

--- a/cpp_utils/test/unittest/utils/utilsTest.cpp
+++ b/cpp_utils/test/unittest/utils/utilsTest.cpp
@@ -446,6 +446,62 @@ TEST(utilsTest, to_bytes)
 }
 
 /**
+ * Test \c from_bytes call
+ */
+TEST(utilsTest, from_bytes)
+{
+    // Zero
+    {
+        const std::uint64_t bytes = 0ULL;
+        const std::string bytes_str = from_bytes(bytes);
+        const std::string bytes_str_expected = "0B";
+        ASSERT_EQ(bytes_str, bytes_str_expected);
+    }
+    // Bytes
+    {
+        const std::uint64_t bytes = 100ULL;
+        const std::string bytes_str = from_bytes(bytes);
+        const std::string bytes_str_expected = "100B";
+        ASSERT_EQ(bytes_str, bytes_str_expected);
+    }
+    // Kilobytes
+    {
+        const std::uint64_t bytes = 555ULL * 1000 + 559;
+        const std::string bytes_str = from_bytes(bytes);
+        const std::string bytes_str_expected = "555.56KB";
+        ASSERT_EQ(bytes_str, bytes_str_expected);
+    }
+    // Megabytes
+    {
+        const std::uint64_t bytes = (100ULL * 1000 + 104) * 1000;
+        const std::string bytes_str = from_bytes(bytes);
+        const std::string bytes_str_expected = "100.10MB";
+        ASSERT_EQ(bytes_str, bytes_str_expected);
+    }
+    // Gigabytes
+    {
+        const std::uint64_t bytes = 82ULL * 1000 * 1000 * 1000;
+        const std::string bytes_str = from_bytes(bytes);
+        const std::string bytes_str_expected = "82GB";
+        ASSERT_EQ(bytes_str, bytes_str_expected);
+    }
+    // Terabytes
+    {
+        const std::uint64_t bytes = 742ULL * 1000 * 1000 * 1000 * 1000;
+        const std::string bytes_str = from_bytes(bytes);
+        const std::string bytes_str_expected = "742TB";
+        ASSERT_EQ(bytes_str, bytes_str_expected);
+    }
+    // Extra Large
+    {
+        const std::uint64_t bytes = 12345ULL * 1000 * 1000 * 1000 * 1000 * 1000;
+        const std::string bytes_str = from_bytes(bytes);
+        const std::string bytes_str_expected = "12345PB";
+        ASSERT_EQ(bytes_str, bytes_str_expected);
+    }
+}
+
+/**
  * Test \c tsnh call
  */
 TEST(utilsTest, tsnh_call)

--- a/cpp_utils/test/unittest/utils/utilsTest.cpp
+++ b/cpp_utils/test/unittest/utils/utilsTest.cpp
@@ -410,6 +410,20 @@ TEST(utilsTest, to_bytes)
         const std::uint64_t bytes_expected = 51ULL * 1024 * 1024 * 1024 * 1024 * 1024;
         ASSERT_EQ(bytes, bytes_expected);
     }
+    // Small decimal number
+    {
+        const std::string bytes_str = "1.50KB";
+        const std::uint64_t bytes = to_bytes(bytes_str);
+        const std::uint64_t bytes_expected = 1ULL * 1000 + 500;
+        ASSERT_EQ(bytes, bytes_expected);
+    }
+    // Large decimal number
+    {
+        const std::string bytes_str = "23.9999GB";
+        const std::uint64_t bytes = to_bytes(bytes_str);
+        const std::uint64_t bytes_expected = ((23ULL * 1000 + 999) * 1000 + 900) * 1000;
+        ASSERT_EQ(bytes, bytes_expected);
+    }
 
     // INVALID
 
@@ -431,11 +445,6 @@ TEST(utilsTest, to_bytes)
     // Invalid unit
     {
         const std::string bytes_str = "100G";
-        ASSERT_THROW(to_bytes(bytes_str), std::invalid_argument);
-    }
-    // Invalid number
-    {
-        const std::string bytes_str = "100.5MB";
         ASSERT_THROW(to_bytes(bytes_str), std::invalid_argument);
     }
     // Number too large


### PR DESCRIPTION
Convert a number of bytes to a string formatted as a number followed by its closest unit (B, KB, MB, GB, TB, PB).