### PR TITLE
[21473] Refactor ReturnCode to Prevent Incompatibilities

### DIFF
--- a/cpp_utils/include/cpp_utils/ReturnCode.hpp
+++ b/cpp_utils/include/cpp_utils/ReturnCode.hpp
@@ -40,17 +40,17 @@ public:
 
     enum ReturnCodeValue
     {
-        OK = 0,
-        ERROR = 1,
-        UNKNOWN = 2,
-        NO_DATA = 3,
-        NOT_ENABLED = 4,
-        PRECONDITION_NOT_MET = 5,
+        RETCODE_OK = 0,
+        RETCODE_ERROR = 1,
+        RETCODE_UNKNOWN = 2,
+        RETCODE_NO_DATA = 3,
+        RETCODE_NOT_ENABLED = 4,
+        RETCODE_PRECONDITION_NOT_MET = 5,
     };
 
     CPP_UTILS_DllAPI
     ReturnCode()
-        : value_(OK)
+        : value_(RETCODE_OK)
     {
     }
 

--- a/cpp_utils/src/cpp/ReturnCode.cpp
+++ b/cpp_utils/src/cpp/ReturnCode.cpp
@@ -33,7 +33,7 @@ ReturnCode::ReturnCode(
     switch (value)
     {
         case fastdds::dds::RETCODE_OK:
-            value_ = ReturnCode::OK;
+            value_ = ReturnCode::RETCODE_OK;
             break;
         case fastdds::dds::RETCODE_ERROR:
         case fastdds::dds::RETCODE_UNSUPPORTED:
@@ -44,19 +44,19 @@ ReturnCode::ReturnCode(
         case fastdds::dds::RETCODE_ALREADY_DELETED:
         case fastdds::dds::RETCODE_TIMEOUT:
         case fastdds::dds::RETCODE_ILLEGAL_OPERATION:
-            value_ = ReturnCode::ERROR;
+            value_ = ReturnCode::RETCODE_ERROR;
             break;
         case fastdds::dds::RETCODE_NO_DATA:
-            value_ = ReturnCode::NO_DATA;
+            value_ = ReturnCode::RETCODE_NO_DATA;
             break;
         case fastdds::dds::RETCODE_NOT_ENABLED:
-            value_ = ReturnCode::NOT_ENABLED;
+            value_ = ReturnCode::RETCODE_NOT_ENABLED;
             break;
         case fastdds::dds::RETCODE_PRECONDITION_NOT_MET:
-            value_ = ReturnCode::PRECONDITION_NOT_MET;
+            value_ = ReturnCode::RETCODE_PRECONDITION_NOT_MET;
             break;
         default:
-            value_ = ReturnCode::UNKNOWN;
+            value_ = ReturnCode::RETCODE_UNKNOWN;
             break;
     }
 }
@@ -86,16 +86,17 @@ bool ReturnCode::operator <(
 
 bool ReturnCode::operator !() const noexcept
 {
-    return value_ != ReturnCode::OK;
+    return value_ != ReturnCode::RETCODE_OK;
 }
 
 const std::map<ReturnCode, std::string> ReturnCode::to_string_conversion_ =
 {
-    {ReturnCode::OK, "Ok"},
-    {ReturnCode::ERROR, "Error"},
-    {ReturnCode::UNKNOWN, "Unknown"},
-    {ReturnCode::NO_DATA, "NoData"},
-    {ReturnCode::PRECONDITION_NOT_MET, "PreconditionNotMet"},
+    {ReturnCode::RETCODE_OK, "Ok"},
+    {ReturnCode::RETCODE_ERROR, "Error"},
+    {ReturnCode::RETCODE_UNKNOWN, "Unknown"},
+    {ReturnCode::RETCODE_NO_DATA, "NoData"},
+    {ReturnCode::RETCODE_NOT_ENABLED, "NotEnabled"},
+    {ReturnCode::RETCODE_PRECONDITION_NOT_MET, "PreconditionNotMet"},
 };
 
 std::ostream& operator <<(

--- a/cpp_utils/test/unittest/return_code/ReturnCodeTest.cpp
+++ b/cpp_utils/test/unittest/return_code/ReturnCodeTest.cpp
@@ -28,11 +28,11 @@ TEST(ReturnCodeTest, serializator)
 {
     std::map<ReturnCode, std::string> to_string_conversion =
     {
-        {ReturnCode::OK, "{Ok}"},
-        {ReturnCode::ERROR, "{Error}"},
-        {ReturnCode::UNKNOWN, "{Unknown}"},
-        {ReturnCode::NO_DATA, "{NoData}"},
-        {ReturnCode::PRECONDITION_NOT_MET, "{PreconditionNotMet}"},
+        {ReturnCode::RETCODE_OK, "{Ok}"},
+        {ReturnCode::RETCODE_ERROR, "{Error}"},
+        {ReturnCode::RETCODE_UNKNOWN, "{Unknown}"},
+        {ReturnCode::RETCODE_NO_DATA, "{NoData}"},
+        {ReturnCode::RETCODE_PRECONDITION_NOT_MET, "{PreconditionNotMet}"},
     };
 
     for (auto it : to_string_conversion)


### PR DESCRIPTION
## Description

This PR refactors the `ReturnCode` enumeration to use the `RETCODE_` format. The update is necessary to ensure compatibility and prevent potential conflicts with existing or future code that may rely on this standardized format.