### PR TITLE
[20274] Add LogFilter struct for filtering log entries by severity levels

### DIFF
--- a/cpp_utils/include/cpp_utils/logging/BaseLogConfiguration.hpp
+++ b/cpp_utils/include/cpp_utils/logging/BaseLogConfiguration.hpp
@@ -14,19 +14,17 @@
 
 #pragma once
 
+#include <ostream>
+
 #include <cpp_utils/library/library_dll.h>
 #include <cpp_utils/Log.hpp>
+#include <cpp_utils/logging/LogFilter.hpp>
 #include <cpp_utils/types/Fuzzy.hpp>
-
-#include <map>
-#include <ostream>
-#include <string>
 
 namespace eprosima {
 namespace utils {
 
 using VerbosityKind = Log::Kind;
-using LogFilter = std::map<VerbosityKind, Fuzzy<std::string>>;
 
 /**
  * The collection of settings related to Logging.
@@ -88,14 +86,6 @@ CPP_UTILS_DllAPI
 std::ostream& operator <<(
         std::ostream& os,
         const Fuzzy<VerbosityKind>& kind);
-
-/**
- * @brief \c LogFilter to stream serialization
- */
-CPP_UTILS_DllAPI
-std::ostream& operator <<(
-        std::ostream& os,
-        const LogFilter& filter);
 
 } /* namespace utils */
 } /* namespace eprosima */

--- a/cpp_utils/include/cpp_utils/logging/BaseLogConsumer.hpp
+++ b/cpp_utils/include/cpp_utils/logging/BaseLogConsumer.hpp
@@ -21,6 +21,7 @@
 #include <cpp_utils/library/library_dll.h>
 #include <cpp_utils/Log.hpp>
 #include <cpp_utils/logging/BaseLogConfiguration.hpp>
+#include <cpp_utils/logging/LogFilter.hpp>
 
 namespace eprosima {
 namespace utils {

--- a/cpp_utils/include/cpp_utils/logging/LogFilter.hpp
+++ b/cpp_utils/include/cpp_utils/logging/LogFilter.hpp
@@ -1,0 +1,53 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License\.
+
+#pragma once
+
+#include <ostream>
+#include <string>
+
+#include <cpp_utils/library/library_dll.h>
+#include <cpp_utils/types/Fuzzy.hpp>
+
+
+namespace eprosima {
+namespace utils {
+
+/**
+ * @brief The LogFilter struct provides filtering options for log entries based on their severity levels.
+ */
+struct LogFilter
+{
+    CPP_UTILS_DllAPI
+    LogFilter() = default;
+
+    /////////////////////////
+    // VARIABLES
+    /////////////////////////
+
+    Fuzzy<std::string> info;
+    Fuzzy<std::string> warning;
+    Fuzzy<std::string> error;
+};
+
+/**
+ * @brief \c LogFilter to stream serialization
+ */
+CPP_UTILS_DllAPI
+std::ostream& operator <<(
+        std::ostream& os,
+        const LogFilter& filter);
+
+} /* namespace utils */
+} /* namespace eprosima */

--- a/cpp_utils/src/cpp/logging/BaseLogConfiguration.cpp
+++ b/cpp_utils/src/cpp/logging/BaseLogConfiguration.cpp
@@ -27,9 +27,6 @@ namespace utils {
 BaseLogConfiguration::BaseLogConfiguration()
     : verbosity{VerbosityKind::Warning, FuzzyLevelValues::fuzzy_level_default}
 {
-    filter[VerbosityKind::Info].set_value("", FuzzyLevelValues::fuzzy_level_default);
-    filter[VerbosityKind::Warning].set_value("", FuzzyLevelValues::fuzzy_level_default);
-    filter[VerbosityKind::Error].set_value("", FuzzyLevelValues::fuzzy_level_default);
 }
 
 bool BaseLogConfiguration::is_valid(
@@ -50,19 +47,19 @@ void BaseLogConfiguration::set(
 void BaseLogConfiguration::set(
         const LogFilter& log_filter)
 {
-    if (filter[VerbosityKind::Error].get_level() <= log_filter.at(VerbosityKind::Error).get_level())
+    if (filter.error.get_level() <= log_filter.error.get_level())
     {
-        filter[VerbosityKind::Error] = log_filter.at(VerbosityKind::Error);
+        filter.error.set_value(log_filter.error.get_value());
     }
 
-    if (filter[VerbosityKind::Warning].get_level() <= log_filter.at(VerbosityKind::Warning).get_level())
+    if (filter.warning.get_level() <= log_filter.warning.get_level())
     {
-        filter[VerbosityKind::Warning] = log_filter.at(VerbosityKind::Warning);
+        filter.warning.set_value(log_filter.warning.get_value());
     }
 
-    if (filter[VerbosityKind::Info].get_level() <= log_filter.at(VerbosityKind::Info).get_level())
+    if (filter.info.get_level() <= log_filter.info.get_level())
     {
-        filter[VerbosityKind::Info] = log_filter.at(VerbosityKind::Info);
+        filter.info.set_value(log_filter.info.get_value());
     }
 }
 
@@ -71,17 +68,6 @@ std::ostream& operator <<(
         const Fuzzy<VerbosityKind>& kind)
 {
     os << "Fuzzy{Level(" << kind.get_level_as_str() << ") " << kind.get_reference() << "}";
-    return os;
-}
-
-std::ostream& operator <<(
-        std::ostream& os,
-        const LogFilter& filter)
-{
-    os << "Log Filter: {Kind: Error, Regex: " << filter.at(VerbosityKind::Error).get_value() << "}; "
-       << "{Kind: Warning, Regex: " << filter.at(VerbosityKind::Warning).get_value() << "}; "
-       << "{Kind: Info, Regex: " << filter.at(VerbosityKind::Info).get_value() << "}";
-
     return os;
 }
 

--- a/cpp_utils/src/cpp/logging/BaseLogConsumer.cpp
+++ b/cpp_utils/src/cpp/logging/BaseLogConsumer.cpp
@@ -35,7 +35,27 @@ bool BaseLogConsumer::accept_entry_(
         const Log::Entry& entry)
 {
     // Filter by regex
-    std::regex filter_regex(filter_[entry.kind].get_value());
+    std::regex filter_regex;
+
+    switch (entry.kind)
+    {
+        case Log::Kind::Error:
+            filter_regex = std::regex(filter_.error.get_value());
+            break;
+
+        case Log::Kind::Warning:
+            filter_regex = std::regex(filter_.warning.get_value());
+            break;
+
+        case Log::Kind::Info:
+            filter_regex = std::regex(filter_.info.get_value());
+            break;
+
+        default:
+            // If the kind is unknown, reject the log entry
+            return false;
+    }
+
     const bool is_category_valid = std::regex_search(entry.context.category, filter_regex);
     const bool is_message_valid = std::regex_search(entry.message, filter_regex);
     const bool is_content_valid = is_category_valid || is_message_valid;

--- a/cpp_utils/src/cpp/logging/LogFilter.cpp
+++ b/cpp_utils/src/cpp/logging/LogFilter.cpp
@@ -1,0 +1,36 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License\.
+
+#include <cpp_utils/logging/LogFilter.hpp>
+
+namespace eprosima {
+namespace utils {
+
+/**
+ * @brief \c LogFilter to stream serialization
+ */
+CPP_UTILS_DllAPI
+std::ostream& operator <<(
+        std::ostream& os,
+        const LogFilter& filter)
+{
+    os << "Log Filter: {Kind: Error, Regex: " << filter.error.get_value() << "}; "
+       << "{Kind: Warning, Regex: " << filter.warning.get_value() << "}; "
+       << "{Kind: Info, Regex: " << filter.info.get_value() << "}";
+
+    return os;
+}
+
+} /* namespace utils */
+} /* namespace eprosima */


### PR DESCRIPTION
This PR introduces the `LogFilter` struct, which provides filtering options for log entries based on their severity levels (`info`, `warning`, and `error`). The `LogFilter` is designed to support flexible matching using the `Fuzzy<std::string>` type for each severity level, allowing for advanced filtering logic.