### PR TITLE
[20761] Add command history navigation in user interface

### DIFF
--- a/cpp_utils/include/cpp_utils/event/StdinEventHandler.hpp
+++ b/cpp_utils/include/cpp_utils/event/StdinEventHandler.hpp
@@ -19,6 +19,7 @@
 #include <thread>
 
 #include <cpp_utils/event/EventHandler.hpp>
+#include <cpp_utils/history/CommandHistoryHandler.hpp>
 #include <cpp_utils/library/library_dll.h>
 #include <cpp_utils/time/time_utils.hpp>
 #include <cpp_utils/wait/CounterWaitHandler.hpp>
@@ -84,6 +85,13 @@ public:
 protected:
 
     /**
+     * @brief TODO
+     */
+    CPP_UTILS_DllAPI
+    void set_terminal_mode_(
+            bool enable) noexcept;
+
+    /**
      * @brief Internal thread to read from \c source_ .
      *
      * This thread waits first to this object to give it permission to start waiting for data in \c source_ by
@@ -119,6 +127,8 @@ protected:
 
     //! Counter that contains the number of times the thread is allowed to start waiting for data from source_.
     CounterWaitHandler activation_times_;
+
+    history::CommandHistoryHandler history_handler_;
 
     /**
      * @brief istream source from where to read.

--- a/cpp_utils/include/cpp_utils/history/CommandHistoryHandler.hpp
+++ b/cpp_utils/include/cpp_utils/history/CommandHistoryHandler.hpp
@@ -1,0 +1,55 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <cpp_utils/library/library_dll.h>
+
+namespace eprosima {
+namespace utils {
+namespace history {
+
+class CommandHistoryHandler
+{
+public:
+
+    /**
+     * @brief TODO
+     */
+    CPP_UTILS_DllAPI
+    CommandHistoryHandler();
+
+    CPP_UTILS_DllAPI
+    void add_command(
+            const std::string& command);
+
+    CPP_UTILS_DllAPI
+    std::string get_previous_command();
+
+    CPP_UTILS_DllAPI
+    std::string get_next_command();
+
+private:
+
+    std::vector<std::string> command_history_;
+
+    size_t current_index_;
+};
+
+} /* namespace history */
+} /* namespace utils */
+} /* namespace eprosima */

--- a/cpp_utils/src/cpp/event/StdinEventHandler.cpp
+++ b/cpp_utils/src/cpp/event/StdinEventHandler.cpp
@@ -21,7 +21,7 @@
 #else
     #include <termios.h>
     #include <unistd.h>
-#endif
+#endif // if defined(_WIN32) || defined(_WIN64)
 
 #include <cpp_utils/event/StdinEventHandler.hpp>
 #include <cpp_utils/exception/InitializationException.hpp>
@@ -53,7 +53,8 @@ void StdinEventHandler::read_one_more_line()
     ++activation_times_;
 }
 
-void StdinEventHandler::set_terminal_mode_(bool enable) noexcept
+void StdinEventHandler::set_terminal_mode_(
+        bool enable) noexcept
 {
 #if defined(_WIN32) || defined(_WIN64)
     static DWORD old_mode;
@@ -102,7 +103,7 @@ void StdinEventHandler::set_terminal_mode_(bool enable) noexcept
         // Restore original terminal configuration
         tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
     }
-#endif
+#endif // if defined(_WIN32) || defined(_WIN64)
 }
 
 void StdinEventHandler::stdin_listener_thread_routine_() noexcept
@@ -135,7 +136,7 @@ void StdinEventHandler::stdin_listener_thread_routine_() noexcept
                 switch (getchar())
                 {
                     case 'A':
-#endif
+#endif // if defined(_WIN32) || defined(_WIN64)
                     {
                         std::string prev_command = history_handler_.get_previous_command();
                         if (!prev_command.empty())
@@ -152,7 +153,7 @@ void StdinEventHandler::stdin_listener_thread_routine_() noexcept
                     case 80:  // Arrow down
 #else
                     case 'B':  // Arrow down
-#endif
+#endif // if defined(_WIN32) || defined(_WIN64)
                     {
                         std::string next_command = history_handler_.get_next_command();
                         if (!next_command.empty())

--- a/cpp_utils/src/cpp/event/StdinEventHandler.cpp
+++ b/cpp_utils/src/cpp/event/StdinEventHandler.cpp
@@ -17,6 +17,7 @@
 #if defined(_WIN32) || defined(_WIN64)
     #define NOMINMAX
     #include <windows.h>
+    #include <conio.h>
 #else
     #include <termios.h>
     #include <unistd.h>
@@ -112,20 +113,22 @@ void StdinEventHandler::stdin_listener_thread_routine_() noexcept
     while (awake_reason == AwakeReason::condition_met)
     {
         std::string read_str;
-        char c;
 
         while (true)
         {
-            c = getchar(); // Read first character
 
 #if defined(_WIN32) || defined(_WIN64)
+            int c;
+            c = _getch(); // Read first character
             if (c == 0 || c == 224)  // Special key prefix for arrow keys on Windows
             {
-                c = getchar(); // Get next character to determine arrow key
+                c = _getch(); // Get next character to determine arrow key
                 switch (c)
                 {
                     case 72:  // Arrow up
 #else
+            char c;
+            c = getchar(); // Read first character
             if (c == '\033')
             {
                 getchar(); // Ignore next character '['
@@ -187,8 +190,9 @@ void StdinEventHandler::stdin_listener_thread_routine_() noexcept
             }
             else
             {
-                read_str += c;
-                std::cout << c;
+                char ch = static_cast<char>(c);
+                read_str += ch;
+                std::cout << ch;
                 std::cout.flush();
             }
         }

--- a/cpp_utils/src/cpp/event/StdinEventHandler.cpp
+++ b/cpp_utils/src/cpp/event/StdinEventHandler.cpp
@@ -77,7 +77,6 @@ void StdinEventHandler::stdin_listener_thread_routine_() noexcept
     set_terminal_mode_(true);
 
     auto awake_reason = activation_times_.wait_and_decrement();
-
     while (awake_reason == AwakeReason::condition_met)
     {
         std::string read_str;

--- a/cpp_utils/src/cpp/history/CommandHistoryHandler.cpp
+++ b/cpp_utils/src/cpp/history/CommandHistoryHandler.cpp
@@ -1,0 +1,62 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cpp_utils/history/CommandHistoryHandler.hpp>
+
+namespace eprosima {
+namespace utils {
+namespace history {
+
+CommandHistoryHandler::CommandHistoryHandler()
+    : current_index_(-1)
+{
+}
+
+void CommandHistoryHandler::add_command(const std::string& command)
+{
+    if (!command.empty())
+    {
+        command_history_.push_back(command);
+        current_index_ = command_history_.size();
+    }
+}
+
+std::string CommandHistoryHandler::get_previous_command()
+{
+    if (!command_history_.empty() && current_index_ > 0)
+    {
+        --current_index_;
+        return command_history_[current_index_];
+    }
+    return "";
+}
+
+std::string CommandHistoryHandler::get_next_command()
+{
+    if (current_index_ < command_history_.size() - 1)
+    {
+        ++current_index_;
+        return command_history_[current_index_];
+    }
+    else if (current_index_ == command_history_.size() - 1)
+    {
+        ++current_index_;
+        return "";
+    }
+    return "";
+}
+
+} /* namespace history */
+} /* namespace utils */
+} /* namespace eprosima */

--- a/cpp_utils/src/cpp/history/CommandHistoryHandler.cpp
+++ b/cpp_utils/src/cpp/history/CommandHistoryHandler.cpp
@@ -23,7 +23,8 @@ CommandHistoryHandler::CommandHistoryHandler()
 {
 }
 
-void CommandHistoryHandler::add_command(const std::string& command)
+void CommandHistoryHandler::add_command(
+        const std::string& command)
 {
     if (!command.empty())
     {

--- a/cpp_utils/test/unittest/event/stdin_event/CMakeLists.txt
+++ b/cpp_utils/test/unittest/event/stdin_event/CMakeLists.txt
@@ -21,11 +21,15 @@ all_library_sources("${TEST_SOURCES}")
 
 set(TEST_LIST
         trivial_create_handler
+    )
+
+if(NOT WIN32)
+    list(APPEND TEST_LIST
         read_lines_start
         read_spaces_start
         read_lines_running
     )
-
+endif()
 set(TEST_EXTRA_LIBRARIES
         fastcdr
         fastdds

--- a/cpp_utils/test/unittest/event/stdin_event/StdinEventHandlerTest.cpp
+++ b/cpp_utils/test/unittest/event/stdin_event/StdinEventHandlerTest.cpp
@@ -19,7 +19,7 @@
     #include <windows.h>
 #else
     #include <unistd.h>
-#endif
+#endif // if defined(_WIN32) || defined(_WIN64)
 
 #include <cpp_utils/testing/gtest_aux.hpp>
 #include <gtest/gtest.h>
@@ -53,7 +53,8 @@ void simulate_stdin(
     HANDLE pipe_read, pipe_write;
 
     // Create a pipe
-    if (!CreatePipe(&pipe_read, &pipe_write, nullptr, 0)) {
+    if (!CreatePipe(&pipe_read, &pipe_write, nullptr, 0))
+    {
         std::cerr << "Pipe creation failed!" << std::endl;
         return;
     }
@@ -79,7 +80,8 @@ void simulate_stdin(
 
 #else
     int pipe_fds[2];
-    if (pipe(pipe_fds) == -1) {
+    if (pipe(pipe_fds) == -1)
+    {
         std::cerr << "Pipe failed!" << std::endl;
         return;
     }
@@ -102,7 +104,7 @@ void simulate_stdin(
     // Redirect stdin to read from the pipe
     dup2(pipe_fds[0], STDIN_FILENO);
     close(pipe_fds[0]);  // Close the reading end of the pipe after redirecting
-#endif
+#endif // if defined(_WIN32) || defined(_WIN64)
 }
 
 /**

--- a/cpp_utils/test/unittest/user_interface/CMakeLists.txt
+++ b/cpp_utils/test/unittest/user_interface/CMakeLists.txt
@@ -21,10 +21,15 @@ all_library_sources("${TEST_SOURCES}")
 
 set(TEST_LIST
         trivial_create
+    )
+
+if (NOT WIN32)
+    list(APPEND TEST_LIST
         read_lines_enum_1
         read_lines_enum_1_negative
         read_lines_enum_2_singleton
     )
+endif()
 
 set(TEST_EXTRA_LIBRARIES
         fastcdr

--- a/cpp_utils/test/unittest/user_interface/CommandReaderTest.cpp
+++ b/cpp_utils/test/unittest/user_interface/CommandReaderTest.cpp
@@ -20,7 +20,7 @@
     #include <windows.h>
 #else
     #include <unistd.h>
-#endif
+#endif // if defined(_WIN32) || defined(_WIN64)
 
 #include <cpp_utils/testing/gtest_aux.hpp>
 #include <gtest/gtest.h>
@@ -75,7 +75,8 @@ void simulate_stdin(
     HANDLE pipe_read, pipe_write;
 
     // Create a pipe
-    if (!CreatePipe(&pipe_read, &pipe_write, nullptr, 0)) {
+    if (!CreatePipe(&pipe_read, &pipe_write, nullptr, 0))
+    {
         std::cerr << "Pipe creation failed!" << std::endl;
         return;
     }
@@ -101,7 +102,8 @@ void simulate_stdin(
 
 #else
     int pipe_fds[2];
-    if (pipe(pipe_fds) == -1) {
+    if (pipe(pipe_fds) == -1)
+    {
         std::cerr << "Pipe failed!" << std::endl;
         return;
     }
@@ -124,7 +126,7 @@ void simulate_stdin(
     // Redirect stdin to read from the pipe
     dup2(pipe_fds[0], STDIN_FILENO);
     close(pipe_fds[0]);  // Close the reading end of the pipe after redirecting
-#endif
+#endif // ifdef _WIN32
 }
 
 } /* namespace test */


### PR DESCRIPTION
This PR introduces the capability to navigate command history within the graphical interface of the application. Users can now utilize the arrow keys to traverse through previously entered commands. Key Changes:

- `CommandHistoryHandler` Class: A new class, `CommandHistoryHandler`, has been created to manage the history of commands. This class handles adding commands to history, as well as retrieving the previous and next commands.

- Integration with `StdinEventHandler`: The `StdinEventHandler` class has been updated to utilize the `CommandHistoryHandler`. When the user presses the up or down arrow keys, the application fetches the appropriate command from the history and displays it in the input area.