### PR TITLE
[23440] Fix time utils time_t 64 bits in windows

### DIFF
--- a/cpp_utils/include/cpp_utils/macros/macros.hpp
+++ b/cpp_utils/include/cpp_utils/macros/macros.hpp
@@ -87,5 +87,11 @@ namespace utils {
 #define _EPROSIMA_WINDOWS_PLATFORM 1
 #endif // if defined(WIN32) || defined(_WIN32) || defined(__WIN32) || defined(WIN64) || defined(_WIN64) || defined(__WIN64) || defined(_MSC_VER)
 
+#if defined(WIN64) || defined(_WIN64) || defined(__WIN64) || defined(_WIN64) || defined(__x86_64__) || defined(__ppc64__) || defined(__aarch64__)
+#define _PLATFORM_64BIT 1
+#else
+#define _PLATFORM_32BIT 1
+#endif
+
 } /* namespace utils */
 } /* namespace eprosima */

--- a/cpp_utils/include/cpp_utils/macros/macros.hpp
+++ b/cpp_utils/include/cpp_utils/macros/macros.hpp
@@ -87,11 +87,12 @@ namespace utils {
 #define _EPROSIMA_WINDOWS_PLATFORM 1
 #endif // if defined(WIN32) || defined(_WIN32) || defined(__WIN32) || defined(WIN64) || defined(_WIN64) || defined(__WIN64) || defined(_MSC_VER)
 
-#if defined(WIN64) || defined(_WIN64) || defined(__WIN64) || defined(_WIN64) || defined(__x86_64__) || defined(__ppc64__) || defined(__aarch64__)
+#if defined(WIN64) || defined(_WIN64) || defined(__WIN64) || defined(_WIN64) || defined(__x86_64__) || \
+    defined(__ppc64__) || defined(__aarch64__)
 #define _PLATFORM_64BIT 1
 #else
 #define _PLATFORM_32BIT 1
-#endif
+#endif // if defined(WIN64) || defined(_WIN64) || defined(__WIN64) || defined(_WIN64) || defined(__x86_64__) || defined(__ppc64__) || defined(__aarch64__)
 
 } /* namespace utils */
 } /* namespace eprosima */

--- a/cpp_utils/include/cpp_utils/time/time_utils.hpp
+++ b/cpp_utils/include/cpp_utils/time/time_utils.hpp
@@ -103,5 +103,17 @@ CPP_UTILS_DllAPI std::chrono::milliseconds duration_to_ms(
 CPP_UTILS_DllAPI void sleep_for(
         const Duration_ms& sleep_time) noexcept;
 
+/**
+ * @brief Makes sure that the time is clamped into a valid range.
+ * This is useful for keeping time values within the ranges
+ * depending on the platform.
+ *
+ * @param time time to normalize.
+ *
+ * @return normalized time value.
+ */
+CPP_UTILS_DllAPI time_t normalize(
+        const time_t& time) noexcept;
+
 } /* namespace utils */
 } /* namespace eprosima */

--- a/cpp_utils/include/cpp_utils/time/time_utils.hpp
+++ b/cpp_utils/include/cpp_utils/time/time_utils.hpp
@@ -32,7 +32,8 @@ using Duration_ms = uint32_t;
 /**
  * Type used to represent time points
  */
-using Timestamp = std::chrono::time_point<std::chrono::system_clock>;
+using Timeclock = std::chrono::system_clock;
+using Timestamp = std::chrono::time_point<Timeclock>;
 
 /**
  * @brief Now time

--- a/cpp_utils/include/cpp_utils/time/time_utils.hpp
+++ b/cpp_utils/include/cpp_utils/time/time_utils.hpp
@@ -30,9 +30,13 @@ namespace utils {
 using Duration_ms = uint32_t;
 
 /**
- * Type used to represent time points
+ * Type used to fix the clock to the system clock
  */
 using Timeclock = std::chrono::system_clock;
+
+/**
+ * Type used to represent time points
+ */
 using Timestamp = std::chrono::time_point<Timeclock>;
 
 /**

--- a/cpp_utils/src/cpp/time/time_utils.cpp
+++ b/cpp_utils/src/cpp/time/time_utils.cpp
@@ -155,7 +155,7 @@ Timestamp string_to_timestamp(
     if ((time_t)-1 == utc_time)
     {
         throw ValueNotAllowedException(
-            STR_ENTRY << "Failed to convert string to timestamp");
+                  STR_ENTRY << "Failed to convert string to timestamp");
     }
 
     return Timeclock::from_time_t(utc_time);

--- a/cpp_utils/src/cpp/time/time_utils.cpp
+++ b/cpp_utils/src/cpp/time/time_utils.cpp
@@ -41,20 +41,20 @@ Timestamp now() noexcept
 
 Timestamp the_end_of_time() noexcept
 {
-    #if defined(_WIN32) // In Windows std::gmtime does not support negative values nor values greater than 2^32
+    #if _EPROSIMA_WINDOWS_PLATFORM // In Windows std::gmtime does not support negative values nor values greater than 2^32
     return Timeclock::from_time_t(std::numeric_limits<long>::max());
     #else
     return Timestamp::max();
-    #endif // if defined(_WIN32)
+    #endif // if _EPROSIMA_WINDOWS_PLATFORM
 }
 
 Timestamp the_beginning_of_time() noexcept
 {
-    #if defined(_WIN32) // In Windows std::gmtime does not support negative values nor values greater than 2^32
+    #if _EPROSIMA_WINDOWS_PLATFORM // In Windows std::gmtime does not support negative values nor values greater than 2^32
     return Timeclock::from_time_t(0);
     #else
     return Timestamp::min();
-    #endif // if defined(_WIN32)
+    #endif // if _EPROSIMA_WINDOWS_PLATFORM
 }
 
 Timestamp date_to_timestamp(
@@ -105,10 +105,10 @@ std::string timestamp_to_string(
     std::ostringstream ss;
     time_t duration_seconds = std::chrono::duration_cast<std::chrono::seconds>(timestamp.time_since_epoch()).count();
 
-    #if defined(_WIN32) // In Windows std::gmtime does not support negative values nor values greater than 2^32
+    #if _EPROSIMA_WINDOWS_PLATFORM // In Windows std::gmtime does not support negative values nor values greater than 2^32
     time_t max_value = std::numeric_limits<long>::max();
     duration_seconds = std::max((time_t) 0, std::min(max_value, duration_seconds));
-    #endif // if defined(_WIN32)
+    #endif // if _EPROSIMA_WINDOWS_PLATFORM
 
     std::tm* tm = nullptr;
     if (local_time)

--- a/cpp_utils/test/unittest/time/time_utils_test.cpp
+++ b/cpp_utils/test/unittest/time/time_utils_test.cpp
@@ -97,7 +97,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
         Timestamp old_time = date_to_timestamp(1970u, 7u, 20u, 6u, 39u, 42u);
         std::string old_time_str = timestamp_to_string(old_time);
 
-        std::ostringstream expected_string_os;  
+        std::ostringstream expected_string_os;
         expected_string_os
             << 1970
             << "-" << "07"
@@ -138,7 +138,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
             << "-" << "12"
             << "-" << "44";
         #endif  // _EPROSIMA_WINDOWS_PLATFORM
-        
+
 
         // Test timestamp_to_string
         ASSERT_EQ(beginning_time_str, expected_string_os.str());
@@ -195,7 +195,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
             << "-" << "47"
             << "-" << "16";
         #endif  // _EPROSIMA_WINDOWS_PLATFORM
-        
+
 
         // Test timestamp_to_string
         ASSERT_EQ(end_time_str, expected_string_os.str());

--- a/cpp_utils/test/unittest/time/time_utils_test.cpp
+++ b/cpp_utils/test/unittest/time/time_utils_test.cpp
@@ -31,8 +31,11 @@ using namespace eprosima::utils;
  * - now
  * - now with alternative format
  * - old time
+ * - the beginning of time
  * - future time
+ * - the end of time
  * - some time today
+ * - wrong date and time
  */
 TEST(time_utils_test, timestamp_to_string_to_timestamp)
 {
@@ -112,14 +115,37 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
         ASSERT_EQ(timestamp_to_string(old_time_from_str), expected_string_os.str());
     }
 
+    // the begininng of time
+    {
+        Timestamp beginning_time = the_beginning_of_time();
+        std::string beginning_time_str = timestamp_to_string(beginning_time);
+
+        std::ostringstream expected_string_os;
+        expected_string_os
+            << 1970
+            << "-" << "01"
+            << "-" << "01"
+            << "_" << "00"
+            << "-" << "00"
+            << "-" << "00";
+
+        // Test timestamp_to_string
+        ASSERT_EQ(beginning_time_str, expected_string_os.str());
+
+        // Test string_to_timestamp
+        Timestamp beginning_time_from_str = string_to_timestamp(beginning_time_str);
+        // NOTE: cannot directly compare timestamps because some precision is lost during ts->str conversion
+        ASSERT_EQ(timestamp_to_string(beginning_time_from_str), expected_string_os.str());
+    }
+
     // future time
     {
-        Timestamp future_time = date_to_timestamp(2233u, 5u, 22u);
+        Timestamp future_time = date_to_timestamp(2033u, 5u, 22u);
         std::string future_time_str = timestamp_to_string(future_time);
 
         std::ostringstream expected_string_os;
         expected_string_os
-            << 2233
+            << 2033
             << "-" << "05"
             << "-" << 22
             << "_" << "00"
@@ -133,6 +159,29 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
         Timestamp future_time_from_str = string_to_timestamp(future_time_str);
         // NOTE: cannot directly compare timestamps because some precision is lost during ts->str conversion
         ASSERT_EQ(timestamp_to_string(future_time_from_str), expected_string_os.str());
+    }
+
+    // the end of time
+    {
+        Timestamp end_time = the_end_of_time();
+        std::string end_time_str = timestamp_to_string(end_time);
+
+        std::ostringstream expected_string_os;
+        expected_string_os
+            << 2038
+            << "-" << "01"
+            << "-" << 19
+            << "_" << "03"
+            << "-" << "14"
+            << "-" << "07";
+
+        // Test timestamp_to_string
+        ASSERT_EQ(end_time_str, expected_string_os.str());
+
+        // Test string_to_timestamp
+        Timestamp end_time_from_str = string_to_timestamp(end_time_str);
+        // NOTE: cannot directly compare timestamps because some precision is lost during ts->str conversion
+        ASSERT_EQ(timestamp_to_string(end_time_from_str), expected_string_os.str());
     }
 
     // some time today

--- a/cpp_utils/test/unittest/time/time_utils_test.cpp
+++ b/cpp_utils/test/unittest/time/time_utils_test.cpp
@@ -97,7 +97,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
         Timestamp old_time = date_to_timestamp(1970u, 7u, 20u, 6u, 39u, 42u);
         std::string old_time_str = timestamp_to_string(old_time);
 
-        std::ostringstream expected_string_os;
+        std::ostringstream expected_string_os;  
         expected_string_os
             << 1970
             << "-" << "07"
@@ -121,6 +121,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
         std::string beginning_time_str = timestamp_to_string(beginning_time);
 
         std::ostringstream expected_string_os;
+        #if _EPROSIMA_WINDOWS_PLATFORM
         expected_string_os
             << 1970
             << "-" << "01"
@@ -128,6 +129,16 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
             << "_" << "00"
             << "-" << "00"
             << "-" << "00";
+        #else //1677-09-21_00-12-44
+        expected_string_os
+            << 1677
+            << "-" << "09"
+            << "-" << "21"
+            << "_" << "00"
+            << "-" << "12"
+            << "-" << "44";
+        #endif  // _EPROSIMA_WINDOWS_PLATFORM
+        
 
         // Test timestamp_to_string
         ASSERT_EQ(beginning_time_str, expected_string_os.str());
@@ -167,6 +178,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
         std::string end_time_str = timestamp_to_string(end_time);
 
         std::ostringstream expected_string_os;
+        #if _EPROSIMA_WINDOWS_PLATFORM
         expected_string_os
             << 2038
             << "-" << "01"
@@ -174,6 +186,16 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
             << "_" << "03"
             << "-" << "14"
             << "-" << "07";
+        #else // 2262-04-11 23:47:16
+        expected_string_os
+            << 2262
+            << "-" << "04"
+            << "-" << 11
+            << "_" << "23"
+            << "-" << "47"
+            << "-" << "16";
+        #endif  // _EPROSIMA_WINDOWS_PLATFORM
+        
 
         // Test timestamp_to_string
         ASSERT_EQ(end_time_str, expected_string_os.str());

--- a/cpp_utils/test/unittest/time/time_utils_test.cpp
+++ b/cpp_utils/test/unittest/time/time_utils_test.cpp
@@ -122,7 +122,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
         std::string old_time_str = timestamp_to_string(old_time);
 
         std::ostringstream expected_string_os;
-        #if _EPROSIMA_WINDOWS_PLATFORM
+#if _EPROSIMA_WINDOWS_PLATFORM
         expected_string_os
             << 1970
             << "-" << "01"
@@ -130,7 +130,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
             << "_" << "00"
             << "-" << "00"
             << "-" << "00";
-        #else
+#else
         expected_string_os
             << 1959
             << "-" << "07"
@@ -138,7 +138,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
             << "_" << "06"
             << "-" << 39
             << "-" << 42;
-        #endif  // _EPROSIMA_WINDOWS_PLATFORM
+#endif  // _EPROSIMA_WINDOWS_PLATFORM
 
         // Test timestamp_to_string
         ASSERT_EQ(old_time_str, expected_string_os.str());
@@ -155,7 +155,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
         std::string beginning_time_str = timestamp_to_string(beginning_time);
 
         std::ostringstream expected_string_os;
-        #if _EPROSIMA_WINDOWS_PLATFORM
+#if _EPROSIMA_WINDOWS_PLATFORM
         expected_string_os
             << 1970
             << "-" << "01"
@@ -163,7 +163,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
             << "_" << "00"
             << "-" << "00"
             << "-" << "00";
-        #else //1677-09-21_00-12-44
+#else //1677-09-21_00-12-44
         expected_string_os
             << 1677
             << "-" << "09"
@@ -171,7 +171,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
             << "_" << "00"
             << "-" << "12"
             << "-" << "44";
-        #endif  // _EPROSIMA_WINDOWS_PLATFORM
+#endif  // _EPROSIMA_WINDOWS_PLATFORM
 
 
         // Test timestamp_to_string
@@ -212,7 +212,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
         std::string future_time_str = timestamp_to_string(future_time);
 
         std::ostringstream expected_string_os;
-        #if _EPROSIMA_WINDOWS_PLATFORM
+#if _EPROSIMA_WINDOWS_PLATFORM && PLATFORM_32BIT
         expected_string_os
             << 2038
             << "-" << "01"
@@ -220,7 +220,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
             << "_" << "03"
             << "-" << "14"
             << "-" << "07";
-        #else
+#else
         expected_string_os
             << 2049
             << "-" << "05"
@@ -228,7 +228,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
             << "_" << "00"
             << "-" << "00"
             << "-" << "00";
-        #endif  // _EPROSIMA_WINDOWS_PLATFORM
+#endif  // _EPROSIMA_WINDOWS_PLATFORM
 
         // Test timestamp_to_string
         ASSERT_EQ(future_time_str, expected_string_os.str());
@@ -245,7 +245,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
         std::string end_time_str = timestamp_to_string(end_time);
 
         std::ostringstream expected_string_os;
-        #if _EPROSIMA_WINDOWS_PLATFORM
+#if _EPROSIMA_WINDOWS_PLATFORM && _PLATFORM_32BIT
         expected_string_os
             << 2038
             << "-" << "01"
@@ -253,7 +253,15 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
             << "_" << "03"
             << "-" << "14"
             << "-" << "07";
-        #else // 2262-04-11 23:47:16
+#elif _EPROSIMA_WINDOWS_PLATFORM && _PLATFORM_64BIT
+        expected_string_os
+            << 3000
+            << "-" << "12"
+            << "-" << 31
+            << "_" << "23"
+            << "-" << "59"
+            << "-" << "59";
+#else // 2262-04-11 23:47:16
         expected_string_os
             << 2262
             << "-" << "04"
@@ -261,7 +269,7 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
             << "_" << "23"
             << "-" << "47"
             << "-" << "16";
-        #endif  // _EPROSIMA_WINDOWS_PLATFORM
+#endif  // _EPROSIMA_WINDOWS_PLATFORM
 
 
         // Test timestamp_to_string

--- a/cpp_utils/test/unittest/time/time_utils_test.cpp
+++ b/cpp_utils/test/unittest/time/time_utils_test.cpp
@@ -31,11 +31,12 @@ using namespace eprosima::utils;
  * - now
  * - now with alternative format
  * - old time
+ * - date before 1970
  * - the beginning of time
  * - future time
+ * - date after 2038
  * - the end of time
  * - some time today
- * - wrong date and time
  */
 TEST(time_utils_test, timestamp_to_string_to_timestamp)
 {
@@ -115,6 +116,39 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
         ASSERT_EQ(timestamp_to_string(old_time_from_str), expected_string_os.str());
     }
 
+    // date before 1970
+    {
+        Timestamp old_time = date_to_timestamp(1959u, 7u, 20u, 6u, 39u, 42u);
+        std::string old_time_str = timestamp_to_string(old_time);
+
+        std::ostringstream expected_string_os;
+        #if _EPROSIMA_WINDOWS_PLATFORM
+        expected_string_os
+            << 1970
+            << "-" << "01"
+            << "-" << "01"
+            << "_" << "00"
+            << "-" << "00"
+            << "-" << "00";
+        #else
+        expected_string_os
+            << 1959
+            << "-" << "07"
+            << "-" << 20
+            << "_" << "06"
+            << "-" << 39
+            << "-" << 42;
+        #endif  // _EPROSIMA_WINDOWS_PLATFORM
+
+        // Test timestamp_to_string
+        ASSERT_EQ(old_time_str, expected_string_os.str());
+
+        // Test string_to_timestamp
+        Timestamp old_time_from_str = string_to_timestamp(old_time_str);
+        // NOTE: cannot directly compare timestamps because some precision is lost during ts->str conversion
+        ASSERT_EQ(timestamp_to_string(old_time_from_str), expected_string_os.str());
+    }
+
     // the begininng of time
     {
         Timestamp beginning_time = the_beginning_of_time();
@@ -162,6 +196,39 @@ TEST(time_utils_test, timestamp_to_string_to_timestamp)
             << "_" << "00"
             << "-" << "00"
             << "-" << "00";
+
+        // Test timestamp_to_string
+        ASSERT_EQ(future_time_str, expected_string_os.str());
+
+        // Test string_to_timestamp
+        Timestamp future_time_from_str = string_to_timestamp(future_time_str);
+        // NOTE: cannot directly compare timestamps because some precision is lost during ts->str conversion
+        ASSERT_EQ(timestamp_to_string(future_time_from_str), expected_string_os.str());
+    }
+
+    // date after 2038
+    {
+        Timestamp future_time = date_to_timestamp(2049u, 5u, 22u);
+        std::string future_time_str = timestamp_to_string(future_time);
+
+        std::ostringstream expected_string_os;
+        #if _EPROSIMA_WINDOWS_PLATFORM
+        expected_string_os
+            << 2038
+            << "-" << "01"
+            << "-" << 19
+            << "_" << "03"
+            << "-" << "14"
+            << "-" << "07";
+        #else
+        expected_string_os
+            << 2049
+            << "-" << "05"
+            << "-" << 22
+            << "_" << "00"
+            << "-" << "00"
+            << "-" << "00";
+        #endif  // _EPROSIMA_WINDOWS_PLATFORM
 
         // Test timestamp_to_string
         ASSERT_EQ(future_time_str, expected_string_os.str());


### PR DESCRIPTION
This PR addresses an issue where Timestamp::max() or Timestamp::min() may exceed the representable range of std::tm, as time_t can be a 64-bit long long int. Specifically, std::tm in Windows cannot express dates before 1970 or beyond 2038.

To resolve this, the PR truncates time_t when converting it to std::tm and adjusts Timestamp::max() and Timestamp::min() to fit within the accepted range on Windows (0 to 2^32).