### PR TITLE
Add Arrow Up/Down feature to navigate Command History and Left/Right Arrow to edit command

### DIFF
--- a/cpp_utils/include/cpp_utils/event/StdinEventHandler.hpp
+++ b/cpp_utils/include/cpp_utils/event/StdinEventHandler.hpp
@@ -81,15 +81,16 @@ public:
      */
     CPP_UTILS_DllAPI
     void read_one_more_line();
-    
+
     /**
      * @brief Temporarily ignore input (disables history addition).
      *
      * Should be called before an interactive command starts and re-enabled after it finishes.
      */
     CPP_UTILS_DllAPI
-    void set_ignore_input(bool ignore) noexcept;
-        
+    void set_ignore_input(
+            bool ignore) noexcept;
+
     /**
      * @brief Check whether input is currently being ignored.
      */
@@ -157,6 +158,7 @@ protected:
     const bool read_lines_;
 
 private:
+
     //! Whether to ignore input (e.g. during interactive commands like echo)
     std::atomic<bool> ignore_input_{false};
 

--- a/cpp_utils/include/cpp_utils/event/StdinEventHandler.hpp
+++ b/cpp_utils/include/cpp_utils/event/StdinEventHandler.hpp
@@ -81,6 +81,20 @@ public:
      */
     CPP_UTILS_DllAPI
     void read_one_more_line();
+    
+    /**
+     * @brief Temporarily ignore input (disables history addition).
+     *
+     * Should be called before an interactive command starts and re-enabled after it finishes.
+     */
+    CPP_UTILS_DllAPI
+    void set_ignore_input(bool ignore) noexcept;
+        
+    /**
+     * @brief Check whether input is currently being ignored.
+     */
+    CPP_UTILS_DllAPI
+    bool is_ignoring_input() const noexcept;
 
 protected:
 
@@ -141,6 +155,11 @@ protected:
 
     //! Whether to read whole lines or stop reading in a space.
     const bool read_lines_;
+
+private:
+    //! Whether to ignore input (e.g. during interactive commands like echo)
+    std::atomic<bool> ignore_input_{false};
+
 };
 
 } /* namespace event */

--- a/cpp_utils/include/cpp_utils/event/StdinEventHandler.hpp
+++ b/cpp_utils/include/cpp_utils/event/StdinEventHandler.hpp
@@ -100,7 +100,12 @@ public:
 protected:
 
     /**
-     * @brief TODO
+     * @brief This function configures the terminal to enable or disable raw input mode.
+     * When `enable` is `true`, it disables line buffering and input echo
+     * so that input can be processed character-by-character without displaying typed characters,
+     * useful for real-time command-line interaction, such as handling arrow keys or passwords.
+     * When `enable` is `false`, it restores the original terminal settings
+     * to avoid leaving the terminal in an unusable state.
      */
     CPP_UTILS_DllAPI
     void set_terminal_mode_(

--- a/cpp_utils/include/cpp_utils/event/StdinEventHandler.hpp
+++ b/cpp_utils/include/cpp_utils/event/StdinEventHandler.hpp
@@ -19,6 +19,7 @@
 #include <thread>
 
 #include <cpp_utils/event/EventHandler.hpp>
+#include <cpp_utils/history/CommandHistoryHandler.hpp>
 #include <cpp_utils/library/library_dll.h>
 #include <cpp_utils/time/time_utils.hpp>
 #include <cpp_utils/wait/CounterWaitHandler.hpp>
@@ -84,6 +85,13 @@ public:
 protected:
 
     /**
+     * @brief TODO
+     */
+    CPP_UTILS_DllAPI
+    void set_terminal_mode_(
+            bool enable) noexcept;
+
+    /**
      * @brief Internal thread to read from \c source_ .
      *
      * This thread waits first to this object to give it permission to start waiting for data in \c source_ by
@@ -119,6 +127,8 @@ protected:
 
     //! Counter that contains the number of times the thread is allowed to start waiting for data from source_.
     CounterWaitHandler activation_times_;
+
+    history::CommandHistoryHandler history_handler_;
 
     /**
      * @brief istream source from where to read.

--- a/cpp_utils/include/cpp_utils/history/CommandHistoryHandler.hpp
+++ b/cpp_utils/include/cpp_utils/history/CommandHistoryHandler.hpp
@@ -1,0 +1,55 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <cpp_utils/library/library_dll.h>
+
+namespace eprosima {
+namespace utils {
+namespace history {
+
+class CommandHistoryHandler
+{
+public:
+
+    /**
+     * @brief TODO
+     */
+    CPP_UTILS_DllAPI
+    CommandHistoryHandler();
+
+    CPP_UTILS_DllAPI
+    void add_command(
+            const std::string& command);
+
+    CPP_UTILS_DllAPI
+    std::string get_previous_command();
+
+    CPP_UTILS_DllAPI
+    std::string get_next_command();
+
+private:
+
+    std::vector<std::string> command_history_;
+
+    size_t current_index_;
+};
+
+} /* namespace history */
+} /* namespace utils */
+} /* namespace eprosima */

--- a/cpp_utils/include/cpp_utils/history/CommandHistoryHandler.hpp
+++ b/cpp_utils/include/cpp_utils/history/CommandHistoryHandler.hpp
@@ -28,7 +28,9 @@ class CommandHistoryHandler
 public:
 
     /**
-     * @brief TODO
+     * @brief This constructor initializes a CommandHistoryHandler instance,
+     * setting current_index_ to -1 to indicate that no command in the history is currently selected.
+     * This is used to manage user input history.
      */
     CPP_UTILS_DllAPI
     CommandHistoryHandler();

--- a/cpp_utils/include/cpp_utils/user_interface/CommandReader.hpp
+++ b/cpp_utils/include/cpp_utils/user_interface/CommandReader.hpp
@@ -110,6 +110,7 @@ protected:
     event::DBQueueWaitHandler<std::string> commands_read_;
 
 public:
+
     event::StdinEventHandler& stdin_handler()
     {
         return stdin_handler_;

--- a/cpp_utils/include/cpp_utils/user_interface/CommandReader.hpp
+++ b/cpp_utils/include/cpp_utils/user_interface/CommandReader.hpp
@@ -108,6 +108,13 @@ protected:
      * value available at a time. But it is the only implementation of ConsumerWaitHandler so far.
      */
     event::DBQueueWaitHandler<std::string> commands_read_;
+
+public:
+    event::StdinEventHandler& stdin_handler()
+    {
+        return stdin_handler_;
+    }
+
 };
 
 } /* namespace utils */

--- a/cpp_utils/include/cpp_utils/utils.hpp
+++ b/cpp_utils/include/cpp_utils/utils.hpp
@@ -83,6 +83,14 @@ void to_lowercase(
         std::string& st) noexcept;
 
 /**
+ * @brief Enables ANSI escape sequence support for colored output in Windows terminals.
+ *
+ * Has no effect on other platforms.
+ */
+CPP_UTILS_DllAPI
+void enable_ansi_colors() noexcept;
+
+/**
  * @brief Convert every alphabetic char in string to upper case
  *
  * @attention This function modifies the object given

--- a/cpp_utils/src/cpp/event/StdinEventHandler.cpp
+++ b/cpp_utils/src/cpp/event/StdinEventHandler.cpp
@@ -21,7 +21,7 @@
 #else
     #include <termios.h>
     #include <unistd.h>
-#endif
+#endif // if defined(_WIN32) || defined(_WIN64)
 
 #include <cpp_utils/event/StdinEventHandler.hpp>
 #include <cpp_utils/exception/InitializationException.hpp>
@@ -53,7 +53,8 @@ void StdinEventHandler::read_one_more_line()
     ++activation_times_;
 }
 
-void StdinEventHandler::set_terminal_mode_(bool enable) noexcept
+void StdinEventHandler::set_terminal_mode_(
+        bool enable) noexcept
 {
 #if defined(_WIN32) || defined(_WIN64)
     static DWORD old_mode;
@@ -102,7 +103,7 @@ void StdinEventHandler::set_terminal_mode_(bool enable) noexcept
         // Restore original terminal configuration
         tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
     }
-#endif
+#endif // if defined(_WIN32) || defined(_WIN64)
 }
 
 void StdinEventHandler::stdin_listener_thread_routine_() noexcept
@@ -135,7 +136,7 @@ void StdinEventHandler::stdin_listener_thread_routine_() noexcept
                 switch (getchar())
                 {
                     case 'A':
-#endif
+#endif // if defined(_WIN32) || defined(_WIN64)
                     {
                         std::string prev_command = history_handler_.get_previous_command();
                         if (!prev_command.empty())
@@ -152,7 +153,7 @@ void StdinEventHandler::stdin_listener_thread_routine_() noexcept
                     case 80:  // Arrow down
 #else
                     case 'B':  // Arrow down
-#endif
+#endif // if defined(_WIN32) || defined(_WIN64)
                     {
                         std::string next_command = history_handler_.get_next_command();
                         if (!next_command.empty())

--- a/cpp_utils/src/cpp/event/StdinEventHandler.cpp
+++ b/cpp_utils/src/cpp/event/StdinEventHandler.cpp
@@ -288,10 +288,7 @@ void StdinEventHandler::stdin_listener_thread_routine_() noexcept
                             clear_lines(lines);
                             read_str = prev_command;
                             cursor_index = read_str.size();
-                            //std::cout << "\r\033[K";
                             std::cout << "\033[38;5;82m" << prompt << "\033[0m" << read_str << std::flush;
-
-                            //std::cout << "\033[38;5;82m>>\033[0m " << read_str << std::flush;
                         }
 
                         break;
@@ -312,8 +309,6 @@ void StdinEventHandler::stdin_listener_thread_routine_() noexcept
                             clear_lines(lines);
                             read_str = next_command;
                             cursor_index = read_str.size();
-                            // std::cout << "\r\033[K";
-                            // std::cout << "\033[38;5;82m>>\033[0m " << read_str << std::flush;
                             std::cout << "\033[38;5;82m" << prompt << "\033[0m" << read_str << std::flush;
                         }
                         else
@@ -326,10 +321,6 @@ void StdinEventHandler::stdin_listener_thread_routine_() noexcept
                             read_str = "";
                             cursor_index = 0;
                             std::cout << "\033[38;5;82m" << prompt << "\033[0m" << std::flush;
-
-                            // read_str = "";
-                            // std::cout << "\r\033[K";
-                            // std::cout << "\033[1;36m>>\033[0m " << std::flush;
                         }
 
                         break;

--- a/cpp_utils/src/cpp/event/StdinEventHandler.cpp
+++ b/cpp_utils/src/cpp/event/StdinEventHandler.cpp
@@ -17,6 +17,7 @@
 #if defined(_WIN32) || defined(_WIN64)
     #define NOMINMAX
     #include <windows.h>
+    #include <conio.h>
 #else
     #include <termios.h>
     #include <unistd.h>
@@ -112,20 +113,22 @@ void StdinEventHandler::stdin_listener_thread_routine_() noexcept
     while (awake_reason == AwakeReason::condition_met)
     {
         std::string read_str;
-        char c;
 
         while (true)
         {
-            c = getchar(); // Read first character
 
 #if defined(_WIN32) || defined(_WIN64)
+            int c;
+            c = _getch(); // Read first character
             if (c == 0 || c == 224)  // Special key prefix for arrow keys on Windows
             {
-                c = getchar(); // Get next character to determine arrow key
+                c = _getch(); // Get next character to determine arrow key
                 switch (c)
                 {
                     case 72:  // Arrow up
 #else
+            char c;
+            c = getchar(); // Read first character
             if (c == '\033')
             {
                 getchar(); // Ignore next character '['
@@ -187,8 +190,9 @@ void StdinEventHandler::stdin_listener_thread_routine_() noexcept
             }
             else
             {
-                read_str += c;
-                std::cout << c;
+                char ch = static_cast<char>(c);
+                read_str += ch;
+                std::cout << ch;
                 std::cout.flush();
             }
         }

--- a/cpp_utils/src/cpp/event/StdinEventHandler.cpp
+++ b/cpp_utils/src/cpp/event/StdinEventHandler.cpp
@@ -200,9 +200,6 @@ void StdinEventHandler::set_terminal_mode_(
     static DWORD old_mode;
     static HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
 
-    static DWORD old_out_mode;
-    static HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
-
     if (enable)
     {
         // Save current input mode
@@ -212,19 +209,11 @@ void StdinEventHandler::set_terminal_mode_(
         DWORD new_mode = old_mode;
         new_mode &= ~(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT);
         SetConsoleMode(hStdin, new_mode);
-
-        // Enable ANSI escape code processing on output
-        GetConsoleMode(hStdout, &old_out_mode);
-        DWORD out_mode = old_out_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-        SetConsoleMode(hStdout, out_mode);
-
-        std::cout << "New console mode set (with ANSI enabled)" << std::endl;
     }
     else
     {
         // Restore input and output modes
         SetConsoleMode(hStdin, old_mode);
-        SetConsoleMode(hStdout, old_out_mode);
     }
 
 #else

--- a/cpp_utils/src/cpp/event/StdinEventHandler.cpp
+++ b/cpp_utils/src/cpp/event/StdinEventHandler.cpp
@@ -77,7 +77,6 @@ void StdinEventHandler::stdin_listener_thread_routine_() noexcept
     set_terminal_mode_(true);
 
     auto awake_reason = activation_times_.wait_and_decrement();
-
     while (awake_reason == AwakeReason::condition_met)
     {
         std::string read_str;

--- a/cpp_utils/src/cpp/history/CommandHistoryHandler.cpp
+++ b/cpp_utils/src/cpp/history/CommandHistoryHandler.cpp
@@ -1,0 +1,62 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cpp_utils/history/CommandHistoryHandler.hpp>
+
+namespace eprosima {
+namespace utils {
+namespace history {
+
+CommandHistoryHandler::CommandHistoryHandler()
+    : current_index_(-1)
+{
+}
+
+void CommandHistoryHandler::add_command(const std::string& command)
+{
+    if (!command.empty())
+    {
+        command_history_.push_back(command);
+        current_index_ = command_history_.size();
+    }
+}
+
+std::string CommandHistoryHandler::get_previous_command()
+{
+    if (!command_history_.empty() && current_index_ > 0)
+    {
+        --current_index_;
+        return command_history_[current_index_];
+    }
+    return "";
+}
+
+std::string CommandHistoryHandler::get_next_command()
+{
+    if (current_index_ < command_history_.size() - 1)
+    {
+        ++current_index_;
+        return command_history_[current_index_];
+    }
+    else if (current_index_ == command_history_.size() - 1)
+    {
+        ++current_index_;
+        return "";
+    }
+    return "";
+}
+
+} /* namespace history */
+} /* namespace utils */
+} /* namespace eprosima */

--- a/cpp_utils/src/cpp/history/CommandHistoryHandler.cpp
+++ b/cpp_utils/src/cpp/history/CommandHistoryHandler.cpp
@@ -23,7 +23,8 @@ CommandHistoryHandler::CommandHistoryHandler()
 {
 }
 
-void CommandHistoryHandler::add_command(const std::string& command)
+void CommandHistoryHandler::add_command(
+        const std::string& command)
 {
     if (!command.empty())
     {

--- a/cpp_utils/src/cpp/utils.cpp
+++ b/cpp_utils/src/cpp/utils.cpp
@@ -83,6 +83,26 @@ bool match_pattern(
 #endif // defined(_WIN32)
 }
 
+void enable_ansi_colors() noexcept
+{
+#if defined(_WIN32) || defined(_WIN64)
+    HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (hStdout == INVALID_HANDLE_VALUE)
+    {
+        return;
+    }
+
+    DWORD mode = 0;
+    if (!GetConsoleMode(hStdout, &mode))
+    {
+        return;
+    }
+
+    mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    SetConsoleMode(hStdout, mode);
+#endif
+}
+
 void to_lowercase(
         std::string& st) noexcept
 {

--- a/cpp_utils/src/cpp/utils.cpp
+++ b/cpp_utils/src/cpp/utils.cpp
@@ -100,7 +100,7 @@ void enable_ansi_colors() noexcept
 
     mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
     SetConsoleMode(hStdout, mode);
-#endif
+#endif // if defined(_WIN32) || defined(_WIN64)
 }
 
 void to_lowercase(

--- a/cpp_utils/test/unittest/event/stdin_event/CMakeLists.txt
+++ b/cpp_utils/test/unittest/event/stdin_event/CMakeLists.txt
@@ -21,11 +21,15 @@ all_library_sources("${TEST_SOURCES}")
 
 set(TEST_LIST
         trivial_create_handler
+    )
+
+if(NOT WIN32)
+    list(APPEND TEST_LIST
         read_lines_start
         read_spaces_start
         read_lines_running
     )
-
+endif()
 set(TEST_EXTRA_LIBRARIES
         fastcdr
         fastdds

--- a/cpp_utils/test/unittest/event/stdin_event/StdinEventHandlerTest.cpp
+++ b/cpp_utils/test/unittest/event/stdin_event/StdinEventHandlerTest.cpp
@@ -19,7 +19,7 @@
     #include <windows.h>
 #else
     #include <unistd.h>
-#endif
+#endif // if defined(_WIN32) || defined(_WIN64)
 
 #include <cpp_utils/testing/gtest_aux.hpp>
 #include <gtest/gtest.h>
@@ -53,7 +53,8 @@ void simulate_stdin(
     HANDLE pipe_read, pipe_write;
 
     // Create a pipe
-    if (!CreatePipe(&pipe_read, &pipe_write, nullptr, 0)) {
+    if (!CreatePipe(&pipe_read, &pipe_write, nullptr, 0))
+    {
         std::cerr << "Pipe creation failed!" << std::endl;
         return;
     }
@@ -79,7 +80,8 @@ void simulate_stdin(
 
 #else
     int pipe_fds[2];
-    if (pipe(pipe_fds) == -1) {
+    if (pipe(pipe_fds) == -1)
+    {
         std::cerr << "Pipe failed!" << std::endl;
         return;
     }
@@ -102,7 +104,7 @@ void simulate_stdin(
     // Redirect stdin to read from the pipe
     dup2(pipe_fds[0], STDIN_FILENO);
     close(pipe_fds[0]);  // Close the reading end of the pipe after redirecting
-#endif
+#endif // if defined(_WIN32) || defined(_WIN64)
 }
 
 /**

--- a/cpp_utils/test/unittest/user_interface/CMakeLists.txt
+++ b/cpp_utils/test/unittest/user_interface/CMakeLists.txt
@@ -21,10 +21,15 @@ all_library_sources("${TEST_SOURCES}")
 
 set(TEST_LIST
         trivial_create
+    )
+
+if (NOT WIN32)
+    list(APPEND TEST_LIST
         read_lines_enum_1
         read_lines_enum_1_negative
         read_lines_enum_2_singleton
     )
+endif()
 
 set(TEST_EXTRA_LIBRARIES
         fastcdr

--- a/cpp_utils/test/unittest/user_interface/CommandReaderTest.cpp
+++ b/cpp_utils/test/unittest/user_interface/CommandReaderTest.cpp
@@ -20,7 +20,7 @@
     #include <windows.h>
 #else
     #include <unistd.h>
-#endif
+#endif // if defined(_WIN32) || defined(_WIN64)
 
 #include <cpp_utils/testing/gtest_aux.hpp>
 #include <gtest/gtest.h>
@@ -75,7 +75,8 @@ void simulate_stdin(
     HANDLE pipe_read, pipe_write;
 
     // Create a pipe
-    if (!CreatePipe(&pipe_read, &pipe_write, nullptr, 0)) {
+    if (!CreatePipe(&pipe_read, &pipe_write, nullptr, 0))
+    {
         std::cerr << "Pipe creation failed!" << std::endl;
         return;
     }
@@ -101,7 +102,8 @@ void simulate_stdin(
 
 #else
     int pipe_fds[2];
-    if (pipe(pipe_fds) == -1) {
+    if (pipe(pipe_fds) == -1)
+    {
         std::cerr << "Pipe failed!" << std::endl;
         return;
     }
@@ -124,7 +126,7 @@ void simulate_stdin(
     // Redirect stdin to read from the pipe
     dup2(pipe_fds[0], STDIN_FILENO);
     close(pipe_fds[0]);  // Close the reading end of the pipe after redirecting
-#endif
+#endif // ifdef _WIN32
 }
 
 } /* namespace test */


### PR DESCRIPTION
This PR continues the work done in 
* https://github.com/eProsima/dev-utils/pull/128

It fixes the visual bugs pointed in this PR, as well as making available Left/Right Arrow to be able to edit commands. This branch must be used together with `feature/command-history` Fast DDS branch.

Merge before: 

* https://github.com/eProsima/Fast-DDS-spy/pull/118