### PR TITLE
Do not use CTRL+C to close the app, only use quit/exit

### DIFF
--- a/cpp_utils/include/cpp_utils/event/StdinEventHandler.hpp
+++ b/cpp_utils/include/cpp_utils/event/StdinEventHandler.hpp
@@ -169,9 +169,6 @@ private:
 
 };
 
-CPP_UTILS_DllAPI extern std::string* global_input_line;
-CPP_UTILS_DllAPI extern size_t* global_cursor_index;
-CPP_UTILS_DllAPI extern std::function<void()> g_sigint_callback;
 } /* namespace event */
 } /* namespace utils */
 } /* namespace eprosima */

--- a/cpp_utils/include/cpp_utils/event/StdinEventHandler.hpp
+++ b/cpp_utils/include/cpp_utils/event/StdinEventHandler.hpp
@@ -169,6 +169,9 @@ private:
 
 };
 
+CPP_UTILS_DllAPI extern std::string* global_input_line;
+CPP_UTILS_DllAPI extern size_t* global_cursor_index;
+CPP_UTILS_DllAPI extern std::function<void()> g_sigint_callback;
 } /* namespace event */
 } /* namespace utils */
 } /* namespace eprosima */

--- a/cpp_utils/src/cpp/event/StdinEventHandler.cpp
+++ b/cpp_utils/src/cpp/event/StdinEventHandler.cpp
@@ -431,7 +431,6 @@ void StdinEventHandler::callback_unset_nts_() noexcept
 {
     activation_times_.disable();
     stdin_listener_thread_.join();
-
 }
 
 void StdinEventHandler::set_ignore_input(

--- a/cpp_utils/src/cpp/event/StdinEventHandler.cpp
+++ b/cpp_utils/src/cpp/event/StdinEventHandler.cpp
@@ -32,11 +32,6 @@ namespace eprosima {
 namespace utils {
 namespace event {
 
- std::string* global_input_line = nullptr;
- size_t* global_cursor_index = nullptr;
-
- std::function<void()> g_sigint_callback = nullptr;
-
 int get_terminal_width()
 {
     #if defined(_WIN32) || defined(_WIN64)
@@ -260,8 +255,6 @@ void StdinEventHandler::stdin_listener_thread_routine_() noexcept
         std::string read_str;
         size_t cursor_index = 0;
 
-        global_input_line = &read_str;
-        global_cursor_index = &cursor_index;
         while (true)
         {
 
@@ -431,30 +424,11 @@ void StdinEventHandler::stdin_listener_thread_routine_() noexcept
 void StdinEventHandler::callback_set_nts_() noexcept
 {
     activation_times_.enable();
-    // g_sigint_callback = [this]()
-    // {
-    // 
-    // std::cout << std::endl;
-    // event_occurred_("");
-// 
-    // if (global_input_line)
-    // {
-        // global_input_line->clear();
-    // }
-// 
-    // if (global_cursor_index)
-    // {
-        // *global_cursor_index = 0;
-    // }
-// 
-    // };
-    
     stdin_listener_thread_ = std::thread(&StdinEventHandler::stdin_listener_thread_routine_, this);
 }
 
 void StdinEventHandler::callback_unset_nts_() noexcept
 {
-    //g_sigint_callback = nullptr;
     activation_times_.disable();
     stdin_listener_thread_.join();
 

--- a/cpp_utils/src/cpp/event/StdinEventHandler.cpp
+++ b/cpp_utils/src/cpp/event/StdinEventHandler.cpp
@@ -232,6 +232,7 @@ void StdinEventHandler::set_terminal_mode_(
         // Modify line mode flags
         // - ICANON: Desactivate canonic mode (process each character)
         // - ECHO: Desactivate echo (does not print what the user writes on terminal)
+        // - ISIG: Deactivate signals (Ctrl+C, Ctrl+Z)
         newt.c_lflag &= ~(ICANON | ECHO | ISIG);
 
         // Apply new configuration


### PR DESCRIPTION
This PR avoids using CTRL+C in fastddsspy to close the application. 

Merge after:
- https://github.com/eProsima/dev-utils/pull/136