### PR TITLE
[24195] Fix ReturnCode comparisons

### DIFF
--- a/cpp_utils/include/cpp_utils/ReturnCode.hpp
+++ b/cpp_utils/include/cpp_utils/ReturnCode.hpp
@@ -74,14 +74,6 @@ public:
             const ReturnCode& c) const noexcept;
 
     CPP_UTILS_DllAPI
-    bool operator ==(
-            const ReturnCodeValue& c) const noexcept;
-
-    CPP_UTILS_DllAPI
-    bool operator !=(
-            const ReturnCodeValue& c) const noexcept;
-
-    CPP_UTILS_DllAPI
     bool operator <(
             const ReturnCode& other) const noexcept;
 

--- a/cpp_utils/include/cpp_utils/ReturnCode.hpp
+++ b/cpp_utils/include/cpp_utils/ReturnCode.hpp
@@ -88,9 +88,8 @@ protected:
     //! Link every ReturnCodeValue available with a string to deserialize
     static const std::map<ReturnCodeValue, std::string> to_string_conversion_;
 
-    //! \c ReturnCode value
-    std::uint32_t value_;
-
+    //! \c ReturnCodeValue
+    ReturnCodeValue value_;
 
     // operator << needs access to the object
     CPP_UTILS_DllAPI

--- a/cpp_utils/include/cpp_utils/ReturnCode.hpp
+++ b/cpp_utils/include/cpp_utils/ReturnCode.hpp
@@ -59,6 +59,10 @@ public:
             const fastdds::dds::ReturnCode_t& value);
 
     CPP_UTILS_DllAPI
+    ReturnCode(
+            const ReturnCodeValue& value);
+
+    CPP_UTILS_DllAPI
     std::uint32_t operator ()() const noexcept;
 
     CPP_UTILS_DllAPI

--- a/cpp_utils/include/cpp_utils/ReturnCode.hpp
+++ b/cpp_utils/include/cpp_utils/ReturnCode.hpp
@@ -70,6 +70,14 @@ public:
             const ReturnCode& c) const noexcept;
 
     CPP_UTILS_DllAPI
+    bool operator ==(
+            const ReturnCodeValue& c) const noexcept;
+
+    CPP_UTILS_DllAPI
+    bool operator !=(
+            const ReturnCodeValue& c) const noexcept;
+
+    CPP_UTILS_DllAPI
     bool operator <(
             const ReturnCode& other) const noexcept;
 

--- a/cpp_utils/include/cpp_utils/ReturnCode.hpp
+++ b/cpp_utils/include/cpp_utils/ReturnCode.hpp
@@ -70,8 +70,16 @@ public:
             const ReturnCode& c) const noexcept;
 
     CPP_UTILS_DllAPI
+    bool operator ==(
+            const ReturnCodeValue& c) const noexcept;
+
+    CPP_UTILS_DllAPI
     bool operator !=(
             const ReturnCode& c) const noexcept;
+
+    CPP_UTILS_DllAPI
+    bool operator !=(
+            const ReturnCodeValue& c) const noexcept;
 
     CPP_UTILS_DllAPI
     bool operator <(
@@ -97,7 +105,27 @@ protected:
             std::ostream& os,
             const ReturnCode& code);
 
+    CPP_UTILS_DllAPI
+    friend bool operator ==(
+            const ReturnCodeValue& lhs,
+            const ReturnCode& rhs) noexcept;
+
+    CPP_UTILS_DllAPI
+    friend bool operator !=(
+            const ReturnCodeValue& lhs,
+            const ReturnCode& rhs) noexcept;
+
 };
+
+CPP_UTILS_DllAPI
+bool operator ==(
+        const ReturnCode::ReturnCodeValue& lhs,
+        const ReturnCode& rhs) noexcept;
+
+CPP_UTILS_DllAPI
+bool operator !=(
+        const ReturnCode::ReturnCodeValue& lhs,
+        const ReturnCode& rhs) noexcept;
 
 //! \c ReturnCode to stream serializator
 CPP_UTILS_DllAPI

--- a/cpp_utils/src/cpp/ReturnCode.cpp
+++ b/cpp_utils/src/cpp/ReturnCode.cpp
@@ -78,6 +78,18 @@ bool ReturnCode::operator !=(
     return value_ != c.value_;
 }
 
+bool ReturnCode::operator ==(
+        const ReturnCodeValue& c) const noexcept
+{
+    return value_ == c;
+}
+
+bool ReturnCode::operator !=(
+        const ReturnCodeValue& c) const noexcept
+{
+    return value_ != c;
+}
+
 bool ReturnCode::operator <(
         const ReturnCode& other) const noexcept
 {

--- a/cpp_utils/src/cpp/ReturnCode.cpp
+++ b/cpp_utils/src/cpp/ReturnCode.cpp
@@ -61,6 +61,12 @@ ReturnCode::ReturnCode(
     }
 }
 
+ReturnCode::ReturnCode(
+        const ReturnCode::ReturnCodeValue& value)
+{
+    value_ = value;
+}
+
 std::uint32_t ReturnCode::operator ()() const noexcept
 {
     return value_;

--- a/cpp_utils/src/cpp/ReturnCode.cpp
+++ b/cpp_utils/src/cpp/ReturnCode.cpp
@@ -84,18 +84,6 @@ bool ReturnCode::operator !=(
     return value_ != c.value_;
 }
 
-bool ReturnCode::operator ==(
-        const ReturnCodeValue& c) const noexcept
-{
-    return value_ == c;
-}
-
-bool ReturnCode::operator !=(
-        const ReturnCodeValue& c) const noexcept
-{
-    return value_ != c;
-}
-
 bool ReturnCode::operator <(
         const ReturnCode& other) const noexcept
 {

--- a/cpp_utils/src/cpp/ReturnCode.cpp
+++ b/cpp_utils/src/cpp/ReturnCode.cpp
@@ -78,10 +78,22 @@ bool ReturnCode::operator ==(
     return value_ == c.value_;
 }
 
+bool ReturnCode::operator ==(
+        const ReturnCode::ReturnCodeValue& c) const noexcept
+{
+    return value_ == c;
+}
+
 bool ReturnCode::operator !=(
         const ReturnCode& c) const noexcept
 {
     return value_ != c.value_;
+}
+
+bool ReturnCode::operator !=(
+        const ReturnCode::ReturnCodeValue& c) const noexcept
+{
+    return value_ != c;
 }
 
 bool ReturnCode::operator <(
@@ -93,6 +105,20 @@ bool ReturnCode::operator <(
 bool ReturnCode::operator !() const noexcept
 {
     return value_ != ReturnCode::RETCODE_OK;
+}
+
+bool operator ==(
+        const ReturnCode::ReturnCodeValue& lhs,
+        const ReturnCode& rhs) noexcept
+{
+    return rhs == lhs;
+}
+
+bool operator !=(
+        const ReturnCode::ReturnCodeValue& lhs,
+        const ReturnCode& rhs) noexcept
+{
+    return rhs != lhs;
 }
 
 const std::map<ReturnCode::ReturnCodeValue, std::string> ReturnCode::to_string_conversion_ =

--- a/cpp_utils/test/unittest/return_code/CMakeLists.txt
+++ b/cpp_utils/test/unittest/return_code/CMakeLists.txt
@@ -21,6 +21,8 @@ set(TEST_SOURCES
 
 set(TEST_LIST
         serializator
+        compare_against_return_code_value_rhs
+        compare_against_return_code_value_lhs
     )
 
 set(TEST_EXTRA_LIBRARIES

--- a/cpp_utils/test/unittest/return_code/ReturnCodeTest.cpp
+++ b/cpp_utils/test/unittest/return_code/ReturnCodeTest.cpp
@@ -43,6 +43,34 @@ TEST(ReturnCodeTest, serializator)
     }
 }
 
+/**
+ * Test ReturnCode compares directly against ReturnCodeValue values.
+ */
+TEST(ReturnCodeTest, compare_against_return_code_value_rhs)
+{
+    // Right side of the comparation
+
+    ReturnCode from_fastdds(fastdds::dds::RETCODE_NO_DATA);
+
+    ASSERT_TRUE(from_fastdds == ReturnCode::RETCODE_NO_DATA);
+    ASSERT_FALSE(from_fastdds == ReturnCode::RETCODE_ERROR);
+    ASSERT_TRUE(from_fastdds != ReturnCode::RETCODE_ERROR);
+}
+
+/**
+ * Test ReturnCodeValue compares directly against ReturnCode from lhs.
+ */
+TEST(ReturnCodeTest, compare_against_return_code_value_lhs)
+{
+    // Left side of the comparation
+
+    ReturnCode ret(ReturnCode::RETCODE_NOT_ENABLED);
+
+    ASSERT_TRUE(ReturnCode::RETCODE_NOT_ENABLED == ret);
+    ASSERT_TRUE(ReturnCode::RETCODE_OK != ret);
+    ASSERT_FALSE(ReturnCode::RETCODE_OK == ret);
+}
+
 int main(
         int argc,
         char** argv)

--- a/cpp_utils/test/unittest/return_code/ReturnCodeTest.cpp
+++ b/cpp_utils/test/unittest/return_code/ReturnCodeTest.cpp
@@ -50,7 +50,7 @@ TEST(ReturnCodeTest, compare_against_return_code_value_rhs)
 {
     // Right side of the comparation
 
-    ReturnCode from_fastdds(fastdds::dds::RETCODE_NO_DATA);
+    ReturnCode from_fastdds(eprosima::fastdds::dds::RETCODE_NO_DATA);
 
     ASSERT_TRUE(from_fastdds == ReturnCode::RETCODE_NO_DATA);
     ASSERT_FALSE(from_fastdds == ReturnCode::RETCODE_ERROR);


### PR DESCRIPTION
Context:

- ReturnCode is a class to handle return codes in dev-utils
- ReturnCodeValue is an enum defined inside ReturnCode, thus it is also in dev-utils
- ReturnCode_t is an enum containing return codes defined in fastdds

Adding comparison operator useful in switch or if else code blocks. Currently, the comparisons of the type

`ReturnCode A == ReturnCode::RETCODE_X  (This is actually of type ReturnCodeValue)
`

are implicitly calling the constructor 

`ReturnCode::ReturnCode(const fastdds::dds::ReturnCode_t& value)
`

for the right operand of the equality. 

**This can lead to issues since that constructor is not designed for variables of the type ReturnCodeValue but it is still called since both enums fall back to integers.**

**A new constructor from type ReturnCodeValue has been added to mitigate this issue**

These are the artifacts generated using this patch on eprosimaCI:

- FastDDS: https://github.com/eProsima/eProsima-CI/actions/runs/20877655060 (should not be needed but may be convenient for having an artifact with the correct name)
- DevUtils: https://github.com/eProsima/eProsima-CI/actions/runs/20848428203
- DDSPipe: https://github.com/eProsima/eProsima-CI/actions/runs/20877688790

Note they all use the suffix "_devutils_retcode_patch"

These are the CI's of the tools that depend on DevUtils running over those artifacts 

- ~~DDSPipe: https://github.com/eProsima/DDS-Pipe/actions/runs/20878338498 (OK)~~
- ~~DDSRouter: https://github.com/eProsima/DDS-Router/actions/runs/20883380087 (OK)~~
- ~~Fast DDS Spy: https://github.com/eProsima/Fast-DDS-spy/actions/runs/20917933468 (OK)~~
- ~~Fast DDS Statistics Backend: https://github.com/eProsima/Fast-DDS-statistics-backend/actions/runs/20877556296 (OK, docs have nothing to do with this PR)~~
- ~~Fast DDS Monitor: - does not have tests -~~
- ~~Fast DDS Record and Replay: https://github.com/eProsima/DDS-Record-Replay/actions/runs/20883351480 (OK, the error is unrelated)~~

NEW TESTS:
- DDSPipe: https://github.com/eProsima/eProsima-CI/actions/runs/22254778507 🟢
- DDSRouter: https://github.com/eProsima/DDS-Router/actions/runs/22255463880 🟢
- Fast DDS Spy: https://github.com/eProsima/Fast-DDS-spy/actions/runs/22255447000 🟢
- Fast DDS Statistics Backend: https://github.com/eProsima/Fast-DDS-statistics-backend/actions/runs/22295239296 🟢 (docs have nothing to do with this PR)
- Fast DDS Monitor: - does not have tests -
- Fast DDS Record and Replay: https://github.com/eProsima/DDS-Record-Replay/actions/runs/22255450872 🟢
