### PR TITLE
[#24061] Updated `read_next_command()` for the new FastDDS-Spy filter

### DIFF
--- a/.github/actions/project_dependencies/action.yml
+++ b/.github/actions/project_dependencies/action.yml
@@ -41,18 +41,18 @@ runs:
   steps:
 
     - name: Install Fast DDS dependencies
-      uses: eProsima/eProsima-CI/multiplatform/install_fastdds_dependencies@v0
+      uses: eProsima/eProsima-CI/multiplatform/install_fastdds_dependencies@main
       with:
         cmake_build_type: ${{ inputs.cmake_build_type }}
 
     - name: Install yaml cpp dependency
-      uses: eProsima/eProsima-CI/multiplatform/install_yamlcpp@v0
+      uses: eProsima/eProsima-CI/multiplatform/install_yamlcpp@main
       with:
         cmake_build_type: ${{ inputs.cmake_build_type }}
 
     # Fast DDS artifact
     - name: Download dependencies artifact
-      uses: eProsima/eProsima-CI/multiplatform/download_dependency@v0
+      uses: eProsima/eProsima-CI/multiplatform/download_dependency@main
       with:
         artifact_name: build_fastdds_${{ inputs.custom_version_build }}_${{ inputs.os }}_${{ inputs.cmake_build_type }}${{ inputs.dependencies_artifact_postfix }}
         workflow_source: build_fastdds.yml

--- a/.github/actions/project_dependencies/action.yml
+++ b/.github/actions/project_dependencies/action.yml
@@ -41,18 +41,18 @@ runs:
   steps:
 
     - name: Install Fast DDS dependencies
-      uses: eProsima/eProsima-CI/multiplatform/install_fastdds_dependencies@main
+      uses: eProsima/eProsima-CI/multiplatform/install_fastdds_dependencies@v0
       with:
         cmake_build_type: ${{ inputs.cmake_build_type }}
 
     - name: Install yaml cpp dependency
-      uses: eProsima/eProsima-CI/multiplatform/install_yamlcpp@main
+      uses: eProsima/eProsima-CI/multiplatform/install_yamlcpp@v0
       with:
         cmake_build_type: ${{ inputs.cmake_build_type }}
 
     # Fast DDS artifact
     - name: Download dependencies artifact
-      uses: eProsima/eProsima-CI/multiplatform/download_dependency@main
+      uses: eProsima/eProsima-CI/multiplatform/download_dependency@v0
       with:
         artifact_name: build_fastdds_${{ inputs.custom_version_build }}_${{ inputs.os }}_${{ inputs.cmake_build_type }}${{ inputs.dependencies_artifact_postfix }}
         workflow_source: build_fastdds.yml

--- a/cpp_utils/include/cpp_utils/user_interface/CommandReader.hpp
+++ b/cpp_utils/include/cpp_utils/user_interface/CommandReader.hpp
@@ -94,6 +94,9 @@ protected:
     void read_command_callback_(
             std::string command_read);
 
+    std::vector<std::string> join_quoted_strings(
+            const std::vector<std::string>& input);
+
     //! Builder to transform string into a command enum value.
     EnumBuilder<CommandEnum> builder_;
 

--- a/cpp_utils/include/cpp_utils/user_interface/CommandReader.hpp
+++ b/cpp_utils/include/cpp_utils/user_interface/CommandReader.hpp
@@ -26,7 +26,7 @@ namespace utils {
  *
  * @tparam CommandEnum enumeration that represent the different commands available.
  */
-template <typename CommandEnum>
+template<typename CommandEnum>
 struct Command
 {
     //! Command in the way of a enumeration class.
@@ -48,7 +48,7 @@ struct Command
  *
  * @note This class relies on \c StdinEventHandler to read from stdin and in \c EnumBuilder to interpret command.
  */
-template <typename CommandEnum>
+template<typename CommandEnum>
 class CommandReader
 {
 public:
@@ -121,7 +121,7 @@ public:
 
 };
 
-} /* namespace utils */
+}     /* namespace utils */
 } /* namespace eprosima */
 
 // Include implementation template file

--- a/cpp_utils/include/cpp_utils/user_interface/CommandReader.hpp
+++ b/cpp_utils/include/cpp_utils/user_interface/CommandReader.hpp
@@ -121,7 +121,7 @@ public:
 
 };
 
-}     /* namespace utils */
+} /* namespace utils */
 } /* namespace eprosima */
 
 // Include implementation template file

--- a/cpp_utils/include/cpp_utils/user_interface/impl/CommandReader.ipp
+++ b/cpp_utils/include/cpp_utils/user_interface/impl/CommandReader.ipp
@@ -45,12 +45,44 @@ bool CommandReader<CommandEnum>::read_next_command(
     std::string full_command = commands_read_.consume();
 
     // Divide command
-    command.arguments = utils::split_string(full_command, " ");
-
+    command.arguments = join_quoted_strings(utils::split_string(full_command, " "));
     // Check if command exists
     // The args are already set in command, and the enum value will be set string_to_enumeration
     return builder_.string_to_enumeration(command.arguments[0], command.command);
 }
+
+template <typename CommandEnum>
+std::vector<std::string> CommandReader<CommandEnum>::join_quoted_strings(
+        const std::vector<std::string>& input)
+{
+    std::vector<std::string> result;
+
+    for (size_t i = 0; i < input.size(); ++i)
+    {
+        // Check if string starts with a quote
+        if (!input[i].empty() && input[i].front() == '"')
+        {
+            std::string joined = input[i];
+
+            // Keep joining until we find a string ending with a quote
+            while (i + 1 < input.size() &&
+                   (joined.empty() || joined.back() != '"'))
+            {
+                joined += " " + input[++i];
+            }
+
+            result.push_back(joined.substr(1, joined.size() - 2));
+        }
+        else
+        {
+            result.push_back(input[i]);
+        }
+    }
+
+    return result;
+}
+
+
 
 template <typename CommandEnum>
 void CommandReader<CommandEnum>::read_command_callback_(

--- a/cpp_utils/include/cpp_utils/user_interface/impl/CommandReader.ipp
+++ b/cpp_utils/include/cpp_utils/user_interface/impl/CommandReader.ipp
@@ -71,7 +71,12 @@ std::vector<std::string> CommandReader<CommandEnum>::join_quoted_strings(
                 joined += " " + input[++i];
             }
 
-            result.push_back(joined.substr(1, joined.size() - 2));
+            // Check if the last character in the joined string is
+            // a closed quote (") or not. If it is a closed quote
+            //  remove it from the string (value = 2)
+            //  otherwise keep all the string (value = 1)
+            int tmp = joined[joined.size() - 1] == '"' ? 2 : 1;
+            result.push_back(joined.substr(1, joined.size() - tmp));
         }
         else
         {
@@ -89,7 +94,7 @@ void CommandReader<CommandEnum>::read_command_callback_(
     commands_read_.produce(command_read);
 }
 
-}     /* namespace utils */
+} /* namespace utils */
 } /* namespace eprosima */
 
 // Include implementation template file

--- a/cpp_utils/include/cpp_utils/user_interface/impl/CommandReader.ipp
+++ b/cpp_utils/include/cpp_utils/user_interface/impl/CommandReader.ipp
@@ -72,9 +72,9 @@ std::vector<std::string> CommandReader<CommandEnum>::join_quoted_strings(
             }
 
             // Check if the last character in the joined string is
-            // a closed quote (") or not. If it is a closed quote
-            //  remove it from the string (value = 2)
-            //  otherwise keep all the string (value = 1)
+            // a closing quote (") or not. If it is a closing quote
+            // remove it from the string (value = 2)
+            // otherwise keep all the string (value = 1)
             int tmp = joined[joined.size() - 1] == '"' ? 2 : 1;
             result.push_back(joined.substr(1, joined.size() - tmp));
         }

--- a/cpp_utils/include/cpp_utils/user_interface/impl/CommandReader.ipp
+++ b/cpp_utils/include/cpp_utils/user_interface/impl/CommandReader.ipp
@@ -17,81 +17,81 @@
 #include <cpp_utils/utils.hpp>
 
 namespace eprosima {
-namespace utils {
+    namespace utils {
 
-template <typename CommandEnum>
-CommandReader<CommandEnum>::CommandReader(
-        const EnumBuilder<CommandEnum>& builder,
-        std::istream& source /* = std::cin */)
-    : builder_(builder)
-    , stdin_handler_(
-        [this](std::string st)
+        template < typename CommandEnum >
+        CommandReader < CommandEnum > ::CommandReader(
+            const EnumBuilder < CommandEnum > &builder,
+            std::istream& source /* = std::cin */)
+            : builder_(builder)
+            , stdin_handler_(
+                [this](std::string st)
         {
             this->read_command_callback_(st);
         },
-        true,
-        0,
-        source)
-    , commands_read_(0, true)
-{
-    // Do nothing
-}
-
-template <typename CommandEnum>
-bool CommandReader<CommandEnum>::read_next_command(
-        Command<CommandEnum>& command)
-{
-    stdin_handler_.read_one_more_line();
-    std::string full_command = commands_read_.consume();
-
-    // Divide command
-    command.arguments = join_quoted_strings(utils::split_string(full_command, " "));
-    // Check if command exists
-    // The args are already set in command, and the enum value will be set string_to_enumeration
-    return builder_.string_to_enumeration(command.arguments[0], command.command);
-}
-
-template <typename CommandEnum>
-std::vector<std::string> CommandReader<CommandEnum>::join_quoted_strings(
-        const std::vector<std::string>& input)
-{
-    std::vector<std::string> result;
-
-    for (size_t i = 0; i < input.size(); ++i)
-    {
-        // Check if string starts with a quote
-        if (!input[i].empty() && input[i].front() == '"')
+                true,
+                0,
+                source)
+            , commands_read_(0, true)
         {
-            std::string joined = input[i];
+            // Do nothing
+        }
 
-            // Keep joining until we find a string ending with a quote
-            while (i + 1 < input.size() &&
-                   (joined.empty() || joined.back() != '"'))
+        template < typename CommandEnum >
+        bool CommandReader < CommandEnum > ::read_next_command(
+            Command < CommandEnum > &command)
+        {
+            stdin_handler_.read_one_more_line();
+            std::string full_command = commands_read_.consume();
+
+            // Divide command
+            command.arguments = join_quoted_strings(utils::split_string(full_command, " "));
+            // Check if command exists
+            // The args are already set in command, and the enum value will be set string_to_enumeration
+            return builder_.string_to_enumeration(command.arguments[0], command.command);
+        }
+
+        template < typename CommandEnum >
+        std::vector < std::string > CommandReader < CommandEnum > ::join_quoted_strings(
+            const std::vector < std::string > &input)
+        {
+            std::vector < std::string > result;
+
+            for (size_t i = 0; i < input.size(); ++i)
             {
-                joined += " " + input[++i];
+                // Check if string starts with a quote
+                if (!input[i].empty() && input[i].front() == '"')
+                {
+                    std::string joined = input[i];
+
+                    // Keep joining until we find a string ending with a quote
+                    while (i + 1 < input.size() &&
+                            (joined.empty() || joined.back() != '"'))
+                    {
+                        joined += " " + input[++i];
+                    }
+
+                    result.push_back(joined.substr(1, joined.size() - 2));
+                }
+                else
+                {
+                    result.push_back(input[i]);
+                }
             }
 
-            result.push_back(joined.substr(1, joined.size() - 2));
+            return result;
         }
-        else
+
+
+
+        template < typename CommandEnum >
+        void CommandReader < CommandEnum > ::read_command_callback_(
+            std::string command_read)
         {
-            result.push_back(input[i]);
+            commands_read_.produce(command_read);
         }
-    }
 
-    return result;
-}
-
-
-
-template <typename CommandEnum>
-void CommandReader<CommandEnum>::read_command_callback_(
-        std::string command_read)
-{
-    commands_read_.produce(command_read);
-}
-
-} /* namespace utils */
+    } /* namespace utils */
 } /* namespace eprosima */
 
 // Include implementation template file

--- a/cpp_utils/include/cpp_utils/user_interface/impl/CommandReader.ipp
+++ b/cpp_utils/include/cpp_utils/user_interface/impl/CommandReader.ipp
@@ -17,81 +17,79 @@
 #include <cpp_utils/utils.hpp>
 
 namespace eprosima {
-    namespace utils {
+namespace utils {
 
-        template < typename CommandEnum >
-        CommandReader < CommandEnum > ::CommandReader(
-            const EnumBuilder < CommandEnum > &builder,
-            std::istream& source /* = std::cin */)
-            : builder_(builder)
-            , stdin_handler_(
-                [this](std::string st)
+template<typename CommandEnum>
+CommandReader<CommandEnum>::CommandReader(
+        const EnumBuilder<CommandEnum>& builder,
+        std::istream& source /* = std::cin */)
+    : builder_(builder)
+    , stdin_handler_(
+        [this](std::string st)
         {
             this->read_command_callback_(st);
         },
-                true,
-                0,
-                source)
-            , commands_read_(0, true)
+        true,
+        0,
+        source)
+    , commands_read_(0, true)
+{
+    // Do nothing
+}
+
+template<typename CommandEnum>
+bool CommandReader<CommandEnum>::read_next_command(
+        Command<CommandEnum>& command)
+{
+    stdin_handler_.read_one_more_line();
+    std::string full_command = commands_read_.consume();
+
+    // Divide command
+    command.arguments = join_quoted_strings(utils::split_string(full_command, " "));
+    // Check if command exists
+    // The args are already set in command, and the enum value will be set string_to_enumeration
+    return builder_.string_to_enumeration(command.arguments[0], command.command);
+}
+
+template<typename CommandEnum>
+std::vector<std::string> CommandReader<CommandEnum>::join_quoted_strings(
+        const std::vector<std::string>& input)
+{
+    std::vector<std::string> result;
+
+    for (size_t i = 0; i < input.size(); ++i)
+    {
+        // Check if string starts with a quote
+        if (!input[i].empty() && input[i].front() == '"')
         {
-            // Do nothing
-        }
+            std::string joined = input[i];
 
-        template < typename CommandEnum >
-        bool CommandReader < CommandEnum > ::read_next_command(
-            Command < CommandEnum > &command)
-        {
-            stdin_handler_.read_one_more_line();
-            std::string full_command = commands_read_.consume();
-
-            // Divide command
-            command.arguments = join_quoted_strings(utils::split_string(full_command, " "));
-            // Check if command exists
-            // The args are already set in command, and the enum value will be set string_to_enumeration
-            return builder_.string_to_enumeration(command.arguments[0], command.command);
-        }
-
-        template < typename CommandEnum >
-        std::vector < std::string > CommandReader < CommandEnum > ::join_quoted_strings(
-            const std::vector < std::string > &input)
-        {
-            std::vector < std::string > result;
-
-            for (size_t i = 0; i < input.size(); ++i)
+            // Keep joining until we find a string ending with a quote
+            while (i + 1 < input.size() &&
+                    (joined.empty() || joined.back() != '"'))
             {
-                // Check if string starts with a quote
-                if (!input[i].empty() && input[i].front() == '"')
-                {
-                    std::string joined = input[i];
-
-                    // Keep joining until we find a string ending with a quote
-                    while (i + 1 < input.size() &&
-                            (joined.empty() || joined.back() != '"'))
-                    {
-                        joined += " " + input[++i];
-                    }
-
-                    result.push_back(joined.substr(1, joined.size() - 2));
-                }
-                else
-                {
-                    result.push_back(input[i]);
-                }
+                joined += " " + input[++i];
             }
 
-            return result;
+            result.push_back(joined.substr(1, joined.size() - 2));
         }
-
-
-
-        template < typename CommandEnum >
-        void CommandReader < CommandEnum > ::read_command_callback_(
-            std::string command_read)
+        else
         {
-            commands_read_.produce(command_read);
+            result.push_back(input[i]);
         }
+    }
 
-    } /* namespace utils */
+    return result;
+}
+
+template<typename CommandEnum>
+void CommandReader<CommandEnum>::read_command_callback_(
+        std::string command_read)
+{
+    commands_read_.produce(command_read);
+}
+
+}     /* namespace utils */
 } /* namespace eprosima */
 
 // Include implementation template file


### PR DESCRIPTION
## Added new function:
```cpp
std::vector<std::string> join_quoted_strings(
        const std::vector<std::string>& input);
```

This function is used in ```read_next_command(Command<CommandEnum>& command)``` to join quotes in a single argument. Used in _FastDDS-Spy_ filter by topic (Content Filtered Topic)

`read_next_command()` it is only used in FastDDS-Spy.  
https://github.com/search?q=org%3AeProsima%20read_next_command(&type=code

## Example
```cpp
// command = filter set topic HelloWorldTopic "index > 10" 

Before: ["filter", "set", "topic", "HelloWorldTopic", "\"index", ">", "10\"" ] // Size: 7
After:  ["filter", "set", "topic", "HelloWorldTopic", "index > 10" ] // Size: 5
```