### PR TITLE
[#24061] Fix wrong tag in nightly ```2.x -> 1.x```

### DIFF
--- a/.github/actions/project_dependencies/action.yml
+++ b/.github/actions/project_dependencies/action.yml
@@ -41,18 +41,18 @@ runs:
   steps:
 
     - name: Install Fast DDS dependencies
-      uses: eProsima/eProsima-CI/multiplatform/install_fastdds_dependencies@v0
+      uses: eProsima/eProsima-CI/multiplatform/install_fastdds_dependencies@main
       with:
         cmake_build_type: ${{ inputs.cmake_build_type }}
 
     - name: Install yaml cpp dependency
-      uses: eProsima/eProsima-CI/multiplatform/install_yamlcpp@v0
+      uses: eProsima/eProsima-CI/multiplatform/install_yamlcpp@main
       with:
         cmake_build_type: ${{ inputs.cmake_build_type }}
 
     # Fast DDS artifact
     - name: Download dependencies artifact
-      uses: eProsima/eProsima-CI/multiplatform/download_dependency@v0
+      uses: eProsima/eProsima-CI/multiplatform/download_dependency@main
       with:
         artifact_name: build_fastdds_${{ inputs.custom_version_build }}_${{ inputs.os }}_${{ inputs.cmake_build_type }}${{ inputs.dependencies_artifact_postfix }}
         workflow_source: build_fastdds.yml

--- a/.github/actions/project_dependencies/action.yml
+++ b/.github/actions/project_dependencies/action.yml
@@ -41,18 +41,18 @@ runs:
   steps:
 
     - name: Install Fast DDS dependencies
-      uses: eProsima/eProsima-CI/multiplatform/install_fastdds_dependencies@main
+      uses: eProsima/eProsima-CI/multiplatform/install_fastdds_dependencies@v0
       with:
         cmake_build_type: ${{ inputs.cmake_build_type }}
 
     - name: Install yaml cpp dependency
-      uses: eProsima/eProsima-CI/multiplatform/install_yamlcpp@main
+      uses: eProsima/eProsima-CI/multiplatform/install_yamlcpp@v0
       with:
         cmake_build_type: ${{ inputs.cmake_build_type }}
 
     # Fast DDS artifact
     - name: Download dependencies artifact
-      uses: eProsima/eProsima-CI/multiplatform/download_dependency@main
+      uses: eProsima/eProsima-CI/multiplatform/download_dependency@v0
       with:
         artifact_name: build_fastdds_${{ inputs.custom_version_build }}_${{ inputs.os }}_${{ inputs.cmake_build_type }}${{ inputs.dependencies_artifact_postfix }}
         workflow_source: build_fastdds.yml

--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       custom_version_build: 'v2'
       dependencies_artifact_postfix: '_nightly'
-      ref: '2.x'
+      ref: '1.x'
     secrets: inherit
 
   reusable_tests_v3:

--- a/.github/workflows/nightly-windows-ci.yml
+++ b/.github/workflows/nightly-windows-ci.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       custom_version_build: 'v2'
       dependencies_artifact_postfix: '_nightly'
-      ref: '2.x'
+      ref: '1.x'
     secrets: inherit
 
   reusable_tests_v3:


### PR DESCRIPTION
## Dev-utils does not have ```2.x branch```

```bash
/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/2.x*:refs/remotes/origin/2.x* +refs/tags/2.x*:refs/tags/2.x*
2026-01-26T05:15:05.4185307Z The process '/usr/bin/git' failed with exit code 1
```

### Action 🟢
https://github.com/eProsima/dev-utils/actions/runs/21441298936