### PR TITLE
Remove nightlies that test dev-utils against Fast DDS 2.x

### DIFF
--- a/.github/workflows/nightly-ubuntu-ci.yml
+++ b/.github/workflows/nightly-ubuntu-ci.yml
@@ -8,15 +8,6 @@ on:
 
 jobs:
 
-  reusable_tests_v2:
-    name: reusable_tests_v2
-    uses: ./.github/workflows/reusable-ubuntu-ci.yml
-    with:
-      custom_version_build: 'v2'
-      dependencies_artifact_postfix: '_nightly'
-      ref: '1.x'
-    secrets: inherit
-
   reusable_tests_v3:
     name: reusable_tests_v3
     uses: ./.github/workflows/reusable-ubuntu-ci.yml

--- a/.github/workflows/nightly-windows-ci.yml
+++ b/.github/workflows/nightly-windows-ci.yml
@@ -8,15 +8,6 @@ on:
 
 jobs:
 
-  reusable_tests_v2:
-    name: reusable_tests_v2
-    uses: ./.github/workflows/reusable-windows-ci.yml
-    with:
-      custom_version_build: 'v2'
-      dependencies_artifact_postfix: '_nightly'
-      ref: '1.x'
-    secrets: inherit
-
   reusable_tests_v3:
     name: reusable_tests_v3
     uses: ./.github/workflows/reusable-windows-ci.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ on:
         default: 'custom'
         options:
           - custom
-          - v2
           - v3
 
       dependencies_artifact_postfix:


### PR DESCRIPTION
As far as I'm concerned, dev-utils is never used over Fast DDS 2.x and it does not seem likely that this will change in the future. This PR just removes those (failing) tests from the CI.