### PR TITLE
[#24574] Disable file watching on macOS and remove invalid InternalPtrData move

### DIFF
--- a/cpp_utils/include/cpp_utils/memory/impl/InternalPtrData.hpp
+++ b/cpp_utils/include/cpp_utils/memory/impl/InternalPtrData.hpp
@@ -30,7 +30,7 @@ namespace eprosima {
 namespace utils {
 
 //! Forward declaration of OwnerPtr to use it as friendly class in LesseePtr
-template <class T>
+template<class T>
 class OwnerPtr;
 
 /**
@@ -43,7 +43,7 @@ class OwnerPtr;
  *
  * @tparam T Type of the internal data.
  */
-template <class T>
+template<class T>
 class InternalPtrData
 {
 public:

--- a/cpp_utils/include/cpp_utils/memory/impl/InternalPtrData.hpp
+++ b/cpp_utils/include/cpp_utils/memory/impl/InternalPtrData.hpp
@@ -55,9 +55,9 @@ public:
     //! Create an empty (non valid) data
     InternalPtrData() noexcept;
 
-    //! Move constructor
+    //! Move constructor is disabled because the internal mutex is not movable
     InternalPtrData(
-            InternalPtrData&& other) noexcept;
+            InternalPtrData&& other) noexcept = delete;
 
     /**
      * @brief Destruct object

--- a/cpp_utils/include/cpp_utils/memory/impl/InternalPtrData.ipp
+++ b/cpp_utils/include/cpp_utils/memory/impl/InternalPtrData.ipp
@@ -35,15 +35,6 @@ InternalPtrData<T>::InternalPtrData() noexcept
 }
 
 template<typename T>
-InternalPtrData<T>::InternalPtrData(
-        InternalPtrData&& other) noexcept
-    : reference_(std::move(other.reference_))
-    , shared_mutex_(std::move(other.shared_mutex_))
-    , deleter_(std::move(other.deleter_))
-{
-}
-
-template<typename T>
 InternalPtrData<T>::~InternalPtrData() noexcept
 {
     // Release data in case it still exists

--- a/cpp_utils/src/cpp/event/FileWatcher.hpp
+++ b/cpp_utils/src/cpp/event/FileWatcher.hpp
@@ -22,7 +22,7 @@
 
 #if !defined(__APPLE__)
 #include <FileWatch.hpp>
-#endif
+#endif // if !defined(__APPLE__)
 
 namespace eprosima {
 namespace utils {
@@ -43,12 +43,13 @@ class FileWatcher
 {
 public:
 
-    template <typename Callback>
+    template<typename Callback>
     FileWatcher(
             std::string,
             Callback&&)
     {
     }
+
 };
 
 #else

--- a/cpp_utils/src/cpp/event/FileWatcher.hpp
+++ b/cpp_utils/src/cpp/event/FileWatcher.hpp
@@ -18,11 +18,40 @@
 
 #pragma once
 
+#include <string>
+
+#if !defined(__APPLE__)
 #include <FileWatch.hpp>
+#endif
 
 namespace eprosima {
 namespace utils {
 namespace event {
+
+#if defined(__APPLE__)
+
+enum class FileWatchEvent
+{
+    added,
+    removed,
+    modified,
+    renamed_old,
+    renamed_new
+};
+
+class FileWatcher
+{
+public:
+
+    template <typename Callback>
+    FileWatcher(
+            std::string,
+            Callback&&)
+    {
+    }
+};
+
+#else
 
 class FileWatcher : public filewatch::FileWatch<std::string>
 {
@@ -31,6 +60,9 @@ class FileWatcher : public filewatch::FileWatch<std::string>
 
 using FileWatchEvent = filewatch::Event;
 
+#endif // defined(__APPLE__)
+
 } /* namespace event */
 } /* namespace utils */
 } /* namespace eprosima */
+

--- a/cpp_utils/src/cpp/event/FileWatcherHandler.cpp
+++ b/cpp_utils/src/cpp/event/FileWatcherHandler.cpp
@@ -82,8 +82,8 @@ void FileWatcherHandler::start_filewatcher_nts_()
     }
     catch (const std::exception& e)
     {
-        utils::InitializationException(STR_ENTRY <<
-                "Error creating file watcher: " << e.what());
+        utils::InitializationException(STR_ENTRY
+                << "Error creating file watcher: " << e.what());
     }
 
     filewatcher_started_.store(true);

--- a/cpp_utils/src/cpp/event/FileWatcherHandler.cpp
+++ b/cpp_utils/src/cpp/event/FileWatcherHandler.cpp
@@ -56,6 +56,12 @@ void FileWatcherHandler::start_filewatcher_nts_()
 {
     logInfo(UTILS_FILEWATCHER, "Starting FileWatcher in file: " << file_path_);
 
+#if defined(__APPLE__)
+    logWarning(
+        UTILS_FILEWATCHER,
+        "File watching is disabled on macOS because the bundled backend only supports Windows and Linux.");
+    filewatcher_started_.store(true);
+#else
     try
     {
         file_watch_handler_ = std::make_unique<FileWatcher>(
@@ -81,6 +87,7 @@ void FileWatcherHandler::start_filewatcher_nts_()
     }
 
     filewatcher_started_.store(true);
+#endif // defined(__APPLE__)
 
     logInfo(UTILS_FILEWATCHER, "Start Watching file: " << file_path_);
 }
@@ -112,3 +119,4 @@ void FileWatcherHandler::callback_unset_nts_() noexcept
 } /* namespace event */
 } /* namespace utils */
 } /* namespace eprosima */
+


### PR DESCRIPTION
## Description

This PR improves native macOS compatibility in `cpp_utils`.

### Changes
- Disable `FileWatcher` on macOS by using a no-op backend under `__APPLE__`.
- Keep `FileWatcherHandler` behavior explicit by logging that file watching is disabled on macOS.
- Remove the `InternalPtrData` move constructor, which attempted to move a `std::shared_timed_mutex`.

## Why

The bundled `filewatch` backend only supports Windows and Linux (`inotify`), so native macOS builds had no valid code path.

Also, `InternalPtrData` tried to move a mutex:
- `std::shared_timed_mutex` is not movable by standard definition
- Apple Clang/libc++ correctly rejects this
- removing the move constructor makes the type standards-compliant

## Error

```bash
Starting >>> cpp_utils
--- stderr: cpp_utils                             
In file included from /Users/macmini/workspace_dev_utils/src/dev-utils/cpp_utils/src/cpp/event/FileWatcherHandler.cpp:25:
In file included from /Users/macmini/workspace_dev_utils/src/dev-utils/cpp_utils/src/cpp/event/FileWatcher.hpp:21:
/Users/macmini/workspace_dev_utils/src/dev-utils/cpp_utils/../thirdparty/filewatch/FileWatch.hpp:98:11: error: initializer '_directory' does not name a non-static data member or base class; did you mean the member '_destory'?
   98 |         , _directory(get_directory(path))
      |           ^~~~~~~~~~
      |           _destory
/Users/macmini/workspace_dev_utils/src/dev-utils/cpp_utils/../thirdparty/filewatch/FileWatch.hpp:171:23: note: '_destory' declared here
  171 |     std::atomic<bool> _destory = { false };
      |                       ^
/Users/macmini/workspace_dev_utils/src/dev-utils/cpp_utils/../thirdparty/filewatch/FileWatch.hpp:132:9: error: use of undeclared identifier '_directory'; did you mean '_destory'?
  132 |         _directory = get_directory(other._path);
      |         ^~~~~~~~~~
      |         _destory
/Users/macmini/workspace_dev_utils/src/dev-utils/cpp_utils/../thirdparty/filewatch/FileWatch.hpp:171:23: note: '_destory' declared here
  171 |     std::atomic<bool> _destory = { false };
      |                       ^
/Users/macmini/workspace_dev_utils/src/dev-utils/cpp_utils/../thirdparty/filewatch/FileWatch.hpp:249:33: error: use of undeclared identifier 'monitor_directory'
  249 |                                 monitor_directory();
      |                                 ^
/Users/macmini/workspace_dev_utils/src/dev-utils/cpp_utils/../thirdparty/filewatch/FileWatch.hpp:98:22: error: use of undeclared identifier 'get_directory'
   98 |         , _directory(get_directory(path))
      |                      ^
/Users/macmini/workspace_dev_utils/src/dev-utils/cpp_utils/../thirdparty/filewatch/FileWatch.hpp:106:11: note: in instantiation of member function 'filewatch::FileWatch<std::string>::FileWatch' requested here
  106 |         : FileWatch<T>(path, UnderpinningRegex(_regex_all), callback)
      |           ^
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/__memory/unique_ptr.h:728:32: note: in instantiation of member function 'filewatch::FileWatch<std::string>::FileWatch' requested here
  728 |     return unique_ptr<_Tp>(new _Tp(_VSTD::forward<_Args>(__args)...));
      |                                ^
/Users/macmini/workspace_dev_utils/src/dev-utils/cpp_utils/src/cpp/event/FileWatcherHandler.cpp:61:36: note: in instantiation of function template specialization 'std::make_unique<eprosima::utils::event::FileWatcher, std::string &, (lambda at /Users/macmini/workspace_dev_utils/src/dev-utils/cpp_utils/src/cpp/event/FileWatcherHandler.cpp:63:13)>' requested here
   61 |         file_watch_handler_ = std::make_unique<FileWatcher>(
      |                                    ^
4 errors generated.
make[2]: *** [CMakeFiles/cpp_utils.dir/src/cpp/event/FileWatcherHandler.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/cpp_utils.dir/all] Error 2
make: *** [all] Error 2
---
Failed   <<< cpp_utils [1.54s, exited with code 2]

Summary: 5 packages finished [3.30s]
  1 package failed: cpp_utils
  3 packages had stderr output: cpp_utils fastcdr fastdds
```